### PR TITLE
feat: extension now generates CRDs instead of apt

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -43,6 +43,10 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-smallrye-health-deployment</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>crd-generator-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -25,9 +25,17 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>1.12.2.Final</quarkus.version>
     <java-operator-sdk.version>1.8.0</java-operator-sdk.version>
+    <kubernetes-client.version>5.2-SNAPSHOT</kubernetes-client.version>
   </properties>
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client-bom</artifactId>
+        <version>${kubernetes-client.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>1.12.2.Final</quarkus.version>
     <java-operator-sdk.version>1.8.0</java-operator-sdk.version>
-    <kubernetes-client.version>5.2-SNAPSHOT</kubernetes-client.version>
+    <kubernetes-client.version>5.2.0</kubernetes-client.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -17,6 +17,12 @@
       <groupId>io.javaoperatorsdk</groupId>
       <artifactId>operator-framework-core</artifactId>
       <version>${java-operator-sdk.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.fabric8</groupId>
+          <artifactId>openshift-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ExternalConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ExternalConfiguration.java
@@ -24,4 +24,10 @@ public class ExternalConfiguration {
      */
     @ConfigItem(defaultValue = "true")
     public Optional<Boolean> checkCRDAndValidateLocalModel;
+
+    /**
+     * The directory where the CRDs will be generated, relative to the project's output directory.
+     */
+    @ConfigItem(defaultValue = "kubernetes")
+    public String crdOutputDirectory;
 }


### PR DESCRIPTION
The output location is configurable using the
`quarkus.operator-sdk.crd-output-directory` property with a path
relative to the output directory of your application.

Currently relies on snapshot version of soon to be released fabric8 kubernetes-client 5.2.

Fixes #5.