### PR TITLE
fix: extract proper controller name from wrapped classes

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -31,7 +31,6 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy-jackson</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>1.12.2.Final</quarkus.version>
-    <java-operator-sdk.version>1.8.1</java-operator-sdk.version>
+    <java-operator-sdk.version>1.8.2</java-operator-sdk.version>
     <kubernetes-client.version>5.2.1</kubernetes-client.version>
   </properties>
   <dependencyManagement>

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
@@ -51,4 +51,17 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
             ResourceController<R> controller) {
         return (ResourceController<R>) unwrapper.apply(controller);
     }
+
+    @Override
+    protected String keyFor(ResourceController controller) {
+        String controllerName = super.keyFor(controller);
+        // heuristics: we're assuming that any class name with an '_' in it is a
+        // proxy / wrapped / generated class and that the "real" class name is located before the
+        // '_'. This probably won't work in all instances but should work most of the time.
+        final int i = controllerName.indexOf('_');
+        if (i > 0) {
+            controllerName = controllerName.substring(0, i);
+        }
+        return controllerName;
+    }
 }


### PR DESCRIPTION
Note that the fix relies on a heuristics so it might not always work.
Unfortunately, there is no standard way to retrieve the "original" class
name after it's been proxied / wrapped several times by different
extensions in different ways… 😭 

Fixes #16