### PR TITLE
use the default quarkus object mapper when initializing the operator.

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorProducer.java
@@ -4,6 +4,8 @@ import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
@@ -17,8 +19,8 @@ public class OperatorProducer {
     @DefaultBean
     @Singleton
     Operator operator(KubernetesClient client, QuarkusConfigurationService configuration,
-            Instance<ResourceController<? extends CustomResource>> controllers) {
-        final var operator = new Operator(client, configuration);
+            Instance<ResourceController<? extends CustomResource>> controllers, ObjectMapper objectMapper) {
+        final var operator = new Operator(client, configuration, objectMapper);
         for (ResourceController<? extends CustomResource> controller : controllers) {
             QuarkusControllerConfiguration<? extends CustomResource> config = configuration
                     .getConfigurationFor(controller);


### PR DESCRIPTION
Hello,
This pull request will initialize the Operator using the default Quarkus ObjectMapper allowing additional modules to be registered (e.g. java.time support).

Please let me know of any feedback you may have.