### PR TITLE
Indicate the branch when pushing the tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,4 +65,5 @@ jobs:
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{github.base_ref}}
           tags: true


### PR DESCRIPTION
For the 1.9 branch.