### PR TITLE
Make the extension able to automatically apply CRDs when not present on the cluster

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
+++ b/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
@@ -1,0 +1,45 @@
+package io.quarkiverse.operatorsdk.deployment;
+
+import io.fabric8.crd.generator.CRDGenerator;
+import io.fabric8.crd.generator.CustomResourceInfo;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.quarkiverse.operatorsdk.runtime.CRDConfiguration;
+import io.quarkiverse.operatorsdk.runtime.CRDGenerationInfo;
+import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+
+class CRDGeneration {
+    private final CRDGenerator generator = new CRDGenerator();
+    private final CRDGenerationInfo.CRDGenerationInfoBuilder builder = CRDGenerationInfo.builder();
+    private boolean generate;
+
+    public CRDGeneration(boolean generate) {
+        this.generate = generate;
+    }
+
+    CRDGenerationInfo generate(OutputTargetBuildItem outputTarget, CRDConfiguration crdConfig,
+            boolean validateCustomResources) {
+        if (generate) {
+            final String outputDirName = crdConfig.outputDirectory;
+            final var outputDir = outputTarget.getOutputDirectory().resolve(outputDirName).toFile();
+            if (!outputDir.exists()) {
+                outputDir.mkdirs();
+            }
+            generator.forCRDVersions(crdConfig.versions).inOutputDir(outputDir).generate();
+            return builder
+                    .forCRDVersions(crdConfig.versions)
+                    .withTargetDir(outputDir)
+                    .validatingCRDs(validateCustomResources)
+                    .applyingCRDs(crdConfig.apply)
+                    .withNamingStrategy(CRDGenerator::getOutputName)
+                    .build();
+        }
+        return new CRDGenerationInfo();
+    }
+
+    public void withCustomResource(Class<CustomResource> crClass, String crdName) {
+        if (generate) {
+            generator.customResources(CustomResourceInfo.fromClass(crClass));
+            builder.withCustomResource(crdName);
+        }
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/ConfigurationServiceBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/ConfigurationServiceBuildItem.java
@@ -2,6 +2,7 @@ package io.quarkiverse.operatorsdk.deployment;
 
 import java.util.List;
 
+import io.quarkiverse.operatorsdk.runtime.CRDGenerationInfo;
 import io.quarkiverse.operatorsdk.runtime.QuarkusControllerConfiguration;
 import io.quarkiverse.operatorsdk.runtime.Version;
 import io.quarkus.builder.item.SimpleBuildItem;
@@ -10,13 +11,13 @@ public final class ConfigurationServiceBuildItem extends SimpleBuildItem {
 
     private final Version version;
     private final List<QuarkusControllerConfiguration> controllerConfigs;
-    private final boolean validateCustomResources;
+    private final CRDGenerationInfo crdInfo;
 
     public ConfigurationServiceBuildItem(Version version,
-            List<QuarkusControllerConfiguration> controllerConfigs, boolean validateCustomResources) {
+            List<QuarkusControllerConfiguration> controllerConfigs, CRDGenerationInfo crdInfo) {
         this.version = version;
         this.controllerConfigs = controllerConfigs;
-        this.validateCustomResources = validateCustomResources;
+        this.crdInfo = crdInfo;
     }
 
     public Version getVersion() {
@@ -27,7 +28,7 @@ public final class ConfigurationServiceBuildItem extends SimpleBuildItem {
         return controllerConfigs;
     }
 
-    public boolean isValidateCustomResources() {
-        return validateCustomResources;
+    public CRDGenerationInfo getCRDGenerationInfo() {
+        return crdInfo;
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDConfiguration.java
@@ -12,7 +12,7 @@ public class CRDConfiguration {
     public static final String DEFAULT_OUTPUT_DIRECTORY = "kubernetes";
     public static final String DEFAULT_VALIDATE = "true";
     public static final String DEFAULT_GENERATE = "true";
-    public static final String DEFAULT_APPLY = "true";
+    public static final String DEFAULT_APPLY = "false";
     public static final String DEFAULT_VERSIONS = "v1";
     /**
      * Whether the operator should check that the CRD is properly deployed and that the associated

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDGenerationInfo.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDGenerationInfo.java
@@ -1,0 +1,111 @@
+package io.quarkiverse.operatorsdk.runtime;
+
+import java.io.File;
+import java.util.*;
+import java.util.function.BiFunction;
+
+public class CRDGenerationInfo {
+    private boolean apply;
+    private boolean validate;
+    private Map<String, Map<String, String>> crds;
+
+    public CRDGenerationInfo() {
+        this(false, true, Collections.emptyMap());
+    }
+
+    private CRDGenerationInfo(boolean apply, boolean validate, Map<String, Map<String, String>> crds) {
+        this.apply = apply;
+        this.validate = validate;
+        this.crds = Collections.unmodifiableMap(crds);
+    }
+
+    public boolean isApply() {
+        return apply;
+    }
+
+    public void setApply(boolean apply) {
+        this.apply = apply;
+    }
+
+    public boolean isValidate() {
+        return validate;
+    }
+
+    public void setValidate(boolean validate) {
+        this.validate = validate;
+    }
+
+    public Map<String, Map<String, String>> getCrds() {
+        return crds;
+    }
+
+    public void setCrds(Map<String, Map<String, String>> crds) {
+        this.crds = crds;
+    }
+
+    public static CRDGenerationInfoBuilder builder() {
+        return new CRDGenerationInfoBuilder();
+    }
+
+    public boolean isApplyCRDs() {
+        return apply;
+    }
+
+    public Map<String, String> getCRDFiles(String crdName) {
+        return crds.get(crdName);
+    }
+
+    public boolean isValidateCRDs() {
+        return validate;
+    }
+
+    public static class CRDGenerationInfoBuilder {
+        private List<String> versions;
+        private File generatedCRDDirectory;
+        private boolean validate;
+        private boolean apply;
+        private BiFunction<String, String, String> namingStrategy;
+        private List<String> crdNames = new ArrayList<>(7);
+
+        public CRDGenerationInfoBuilder forCRDVersions(List<String> versions) {
+            this.versions = versions;
+            return this;
+        }
+
+        public CRDGenerationInfoBuilder withTargetDir(File generatedCRDDirectory) {
+            this.generatedCRDDirectory = generatedCRDDirectory;
+            return this;
+        }
+
+        public CRDGenerationInfo build() {
+            // for each CRD name, get the CRD file path for each requested CRD spec version
+            final Map<String, Map<String, String>> crdNamesToVersionsMap = new HashMap<>(crdNames.size());
+            crdNames.forEach(name -> versions.forEach(v -> crdNamesToVersionsMap
+                    .computeIfAbsent(name, s -> new HashMap<>())
+                    .put(v, new File(generatedCRDDirectory, namingStrategy.apply(name, v) + ".yml").getAbsolutePath())));
+
+            return new CRDGenerationInfo(apply, validate, crdNamesToVersionsMap);
+        }
+
+        public CRDGenerationInfoBuilder validatingCRDs(boolean validateCustomResources) {
+            this.validate = validateCustomResources;
+            return this;
+        }
+
+        public CRDGenerationInfoBuilder applyingCRDs(boolean apply) {
+            this.apply = apply;
+            return this;
+        }
+
+        public CRDGenerationInfoBuilder withNamingStrategy(BiFunction<String, String, String> namingStrategy) {
+            this.namingStrategy = namingStrategy;
+            return this;
+        }
+
+        public CRDGenerationInfoBuilder withCustomResource(String crdName) {
+            crdNames.add(crdName);
+            return this;
+        }
+    }
+
+}

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
@@ -15,7 +15,7 @@ public class ConfigurationServiceRecorder {
 
     public Supplier<QuarkusConfigurationService> configurationServiceSupplier(Version version,
             List<QuarkusControllerConfiguration> configurations,
-            boolean validateCustomResources, RunTimeOperatorConfiguration runTimeConfiguration) {
+            CRDGenerationInfo crdInfo, RunTimeOperatorConfiguration runTimeConfiguration) {
         final var maxThreads = runTimeConfiguration.concurrentReconciliationThreads
                 .orElse(ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
         final var timeout = runTimeConfiguration.terminationTimeoutSeconds
@@ -34,7 +34,9 @@ public class ConfigurationServiceRecorder {
                 version,
                 configurations,
                 Arc.container().instance(KubernetesClient.class).get(),
-                validateCustomResources, maxThreads, timeout,
+                crdInfo,
+                maxThreads,
+                timeout,
                 Arc.container().instance(ObjectMapper.class).get());
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorProducer.java
@@ -1,17 +1,27 @@
 package io.quarkiverse.operatorsdk.runtime;
 
+import java.io.File;
+
 import javax.enterprise.inject.Instance;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
+import org.jboss.logging.Logger;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+
+import io.fabric8.kubernetes.api.model.apiextensions.v1.CustomResourceDefinition;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.javaoperatorsdk.operator.MissingCRDException;
 import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.ResourceController;
 import io.quarkus.arc.DefaultBean;
 
 @Singleton
 public class OperatorProducer {
+    private static final YAMLMapper mapper = new YAMLMapper();
+    private static final Logger log = Logger.getLogger(OperatorProducer.class.getName());
 
     @Produces
     @DefaultBean
@@ -23,9 +33,60 @@ public class OperatorProducer {
             QuarkusControllerConfiguration<? extends CustomResource> config = configuration
                     .getConfigurationFor(controller);
             if (!config.isRegistrationDelayed()) {
-                operator.register(controller);
+                try {
+                    operator.register(controller);
+                } catch (MissingCRDException e) {
+                    final var crdInfo = configuration.getCRDGenerationInfo();
+                    if (crdInfo.isApplyCRDs()) {
+                        final var crdName = config.getCRDName();
+                        try {
+                            crdInfo.getCRDFiles(crdName).forEach((crdVersion, fileName) -> {
+                                final var crdFile = new File(fileName);
+                                try {
+                                    final var crd = mapper.readValue(crdFile, getCRDClassFor(crdVersion));
+                                    apply(client, crdVersion, crd);
+                                    log.infov("Applied {0} CRD named ''{1}'' from {2}", crdVersion, crdName, fileName);
+                                } catch (Exception ex) {
+                                    throw new RuntimeException(ex);
+                                }
+                            });
+                        } catch (Exception exception) {
+                            log.debugv(exception, "Couldn't apply ''{0}'' CRD", crdName);
+                        }
+
+                        // re-register the controller
+                        operator.register(controller);
+                    } else {
+                        throw e;
+                    }
+                }
             }
         }
         return operator;
+    }
+
+    private static void apply(KubernetesClient client, String v, Object crd) {
+        switch (v) {
+            case "v1":
+                client.apiextensions().v1().customResourceDefinitions().createOrReplace((CustomResourceDefinition) crd);
+                break;
+            case "v1beta1":
+                client.apiextensions().v1beta1().customResourceDefinitions()
+                        .createOrReplace((io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition) crd);
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown CRD version: " + v);
+        }
+    }
+
+    private static Class<?> getCRDClassFor(String v) {
+        switch (v) {
+            case "v1":
+                return CustomResourceDefinition.class;
+            case "v1beta1":
+                return io.fabric8.kubernetes.api.model.apiextensions.v1beta1.CustomResourceDefinition.class;
+            default:
+                throw new IllegalArgumentException("Unknown CRD version: " + v);
+        }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
@@ -16,7 +16,7 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
 
     private static final ClientProxyUnwrapper unwrapper = new ClientProxyUnwrapper();
     private final KubernetesClient client;
-    private final boolean checkCRDAndValidateLocalModel;
+    private final CRDGenerationInfo crdInfo;
     private final int concurrentReconciliationThreads;
     private final ObjectMapper mapper;
     private int terminationTimeout;
@@ -26,7 +26,7 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
             Version version,
             List<QuarkusControllerConfiguration> configurations,
             KubernetesClient client,
-            boolean checkCRDAndValidateLocalModel, int maxThreads,
+            CRDGenerationInfo crdInfo, int maxThreads,
             int timeout, ObjectMapper mapper) {
         super(version);
         this.client = client;
@@ -40,7 +40,7 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
         } else {
             controllerClassToName = Collections.emptyMap();
         }
-        this.checkCRDAndValidateLocalModel = checkCRDAndValidateLocalModel;
+        this.crdInfo = crdInfo;
         this.concurrentReconciliationThreads = maxThreads;
         this.terminationTimeout = timeout;
     }
@@ -59,7 +59,7 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
 
     @Override
     public boolean checkCRDAndValidateLocalModel() {
-        return checkCRDAndValidateLocalModel;
+        return crdInfo.isValidateCRDs();
     }
 
     private static <R extends CustomResource> ResourceController<R> unwrap(
@@ -101,4 +101,11 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
         return terminationTimeout;
     }
 
+    public boolean isApplyCRDs() {
+        return crdInfo.isApplyCRDs();
+    }
+
+    public CRDGenerationInfo getCRDGenerationInfo() {
+        return crdInfo;
+    }
 }

--- a/samples/src/main/resources/application.properties
+++ b/samples/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 joke-api/mp-rest/url=https://v2.jokeapi.dev/joke
 joke-api/mp-rest/scope=javax.inject.Singleton
+quarkus.operator-sdk.crd.apply=true


### PR DESCRIPTION
This only partially addresses the UX of applying CRDs when missing as it only deals with the case where the CRD is missing during the controller's registration.