### PR TITLE
feat: make it possible to set default values for all controllers

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -182,7 +182,8 @@ class OperatorSDKProcessor {
                     controllerAnnotation);
 
             // extract the configuration from annotation and/or external configuration
-            final var configExtractor = new BuildTimeHybridControllerConfiguration(buildTimeConfiguration.controllers.get(name),
+            final var configExtractor = new BuildTimeHybridControllerConfiguration(buildTimeConfiguration,
+                    buildTimeConfiguration.controllers.get(name),
                     controllerAnnotation, info.classAnnotation(DELAY_REGISTRATION));
 
             if (configExtractor.delayedRegistration()) {
@@ -277,7 +278,8 @@ class OperatorSDKProcessor {
         // retrieve the controller's name
         final String name = getControllerName(resourceControllerClassName, controllerAnnotation);
 
-        final var configExtractor = new BuildTimeHybridControllerConfiguration(buildTimeConfiguration.controllers.get(name),
+        final var configExtractor = new BuildTimeHybridControllerConfiguration(buildTimeConfiguration,
+                buildTimeConfiguration.controllers.get(name),
                 controllerAnnotation, delayedRegistrationAnnotation);
 
         // create the configuration

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
@@ -144,8 +144,14 @@ public class OperatorSDKResource {
             return (String[]) conf.getNamespaces().toArray(new String[0]);
         }
 
+        @JsonProperty("watchAllNamespaces")
         public boolean watchAllNamespaces() {
             return conf.watchAllNamespaces();
+        }
+
+        @JsonProperty("watchCurrentNamespace")
+        public boolean watchCurrentNamespace() {
+            return conf.watchCurrentNamespace();
         }
 
         public RetryConfiguration getRetryConfiguration() {
@@ -155,6 +161,11 @@ public class OperatorSDKResource {
         public boolean isDelayed() {
             return conf instanceof QuarkusControllerConfiguration
                     && ((QuarkusControllerConfiguration) conf).isRegistrationDelayed();
+        }
+
+        @JsonProperty("useFinalizer")
+        public boolean useFinalizer() {
+            return conf.useFinalizer();
         }
     }
 }

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,3 +1,6 @@
+quarkus.operator-sdk.finalizer=JOSDK_NO_FINALIZER
+quarkus.operator-sdk.namespaces=JOSDK_WATCH_CURRENT
+quarkus.operator-sdk.generation-aware=false
 quarkus.operator-sdk.controllers.annotation.finalizer=from-property/finalizer
 quarkus.operator-sdk.controllers.annotation.namespaces=bar
 quarkus.operator-sdk.controllers.annotation.retry.max-attempts=10

--- a/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
@@ -56,7 +56,7 @@ public class OperatorSDKResourceTest {
     }
 
     @Test
-    void configurationForControllerShouldExist() {
+    void configurationForControllerShouldExistAndUseOperatorLevelConfigurationWhenSet() {
         // check that the config for the test controller can be retrieved and is conform to our
         // expectations
         final var resourceName = ChildTestResource.class.getCanonicalName();
@@ -67,7 +67,10 @@ public class OperatorSDKResourceTest {
                 .statusCode(200)
                 .body(
                         "customResourceClass", equalTo(resourceName),
-                        "name", equalTo(TestController.NAME));
+                        "name", equalTo(TestController.NAME),
+                        "useFinalizer", equalTo(false),
+                        "watchCurrentNamespace", equalTo(true),
+                        "generationAware", equalTo(false));
     }
 
     @Test

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
@@ -34,4 +34,16 @@ public class BuildTimeOperatorConfiguration {
     @ConfigItem
     public CRDConfiguration crd;
 
+    /**
+     * Whether controllers should only process events if the associated resource generation has
+     * increased since last reconciliation, otherwise will process all events. Sets the default value for all controllers.
+     */
+    @ConfigItem(defaultValue = "true")
+    public Optional<Boolean> generationAware;
+
+    /**
+     * The optional fully qualified name of a CDI event class that controllers will wait for before
+     * registering with the Operator. Sets the default value for all controllers.
+     */
+    public Optional<String> delayRegistrationUntilEvent;
 }

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
@@ -23,6 +23,11 @@ public class ConfigurationServiceRecorder {
 
         configurations.forEach(c -> {
             final var extConfig = runTimeConfiguration.controllers.get(c.getName());
+            // first use the operator-level configuration if set
+            runTimeConfiguration.finalizer.ifPresent(c::setFinalizer);
+            runTimeConfiguration.namespaces.ifPresent(c::setNamespaces);
+
+            // then override with controller-specific configuration if present
             if (extConfig != null) {
                 extConfig.finalizer.ifPresent(c::setFinalizer);
                 extConfig.namespaces.ifPresent(c::setNamespaces);

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/RunTimeOperatorConfiguration.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/RunTimeOperatorConfiguration.java
@@ -14,6 +14,7 @@
  */
 package io.quarkiverse.operatorsdk.runtime;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -42,4 +43,20 @@ public class RunTimeOperatorConfiguration {
     @ConfigItem
     public Optional<Integer> terminationTimeoutSeconds;
 
+    /**
+     * An optional list of comma-separated namespace names all controllers will watch if not specified. If this
+     * property is left empty then controllers will watch all namespaces by default. Sets the default value for all controllers.
+     */
+    @ConfigItem
+    public Optional<List<String>> namespaces;
+
+    /**
+     * The optional name of the finalizer to use for controllers. If none is provided, one will be
+     * automatically generated. It should be noted that having several controllers use the same finalizer might
+     * create issues and this configuration item is mostly useful when we don't want to use finalizers at all by
+     * default (using the {@link io.javaoperatorsdk.operator.api.Controller#NO_FINALIZER} value). Sets the default value for all
+     * controllers.
+     */
+    @ConfigItem
+    public Optional<String> finalizer;
 }


### PR DESCRIPTION
Properties at the `quarkus.operator-sdk` level can set defaults for
similarly named controller-specific properties, which will take effect
for all controllers that do not specifically override the value.

Fixes #74