### PR TITLE
Apply CRD when changes happened during dev that impact them

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
+++ b/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.operatorsdk.deployment;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
 import io.fabric8.crd.generator.CRDGenerator;
@@ -37,6 +38,8 @@ class CRDGeneration {
             boolean validateCustomResources, Map<String, Map<String, CRDInfo>> existing) {
         // initialize CRDInfo with existing data to always have a full view even if we don't generate anything
         final var converted = new HashMap<>(existing);
+        // record which CRDs got generated so that we only apply the changed ones
+        final var generated = new HashSet<String>();
 
         if (needGeneration) {
             final String outputDirName = crdConfig.outputDirectory;
@@ -49,6 +52,7 @@ class CRDGeneration {
 
             crdDetailsPerNameAndVersion.forEach((crdName, initialVersionToCRDInfoMap) -> {
                 OperatorSDKProcessor.log.infov("Generated {0} CRD:", crdName);
+                generated.add(crdName);
 
                 final var versionToCRDInfo = converted.computeIfAbsent(crdName, s -> new HashMap<>());
                 initialVersionToCRDInfoMap
@@ -60,7 +64,7 @@ class CRDGeneration {
                         });
             });
         }
-        return new CRDGenerationInfo(crdConfig.apply, validateCustomResources, converted);
+        return new CRDGenerationInfo(crdConfig.apply, validateCustomResources, converted, generated);
     }
 
     public void withCustomResource(Class<CustomResource> crClass, String crdName) {

--- a/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/ContextStoredCRDInfos.java
+++ b/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/ContextStoredCRDInfos.java
@@ -8,8 +8,12 @@ import io.quarkiverse.operatorsdk.runtime.CRDInfo;
 public class ContextStoredCRDInfos {
     private Map<String, Map<String, CRDInfo>> infos = new HashMap<>();
 
-    public Map<String, CRDInfo> getCRDInfosFor(String crdName) {
+    Map<String, CRDInfo> getCRDInfosFor(String crdName) {
         return infos.computeIfAbsent(crdName, k -> new HashMap<>());
+    }
+
+    public Map<String, Map<String, CRDInfo>> getExisting() {
+        return infos;
     }
 
     void putAll(Map<String, Map<String, CRDInfo>> toAdd) {

--- a/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -55,7 +55,7 @@ import io.quarkus.runtime.QuarkusApplication;
 
 class OperatorSDKProcessor {
 
-    private static final Logger log = Logger.getLogger(OperatorSDKProcessor.class.getName());
+    static final Logger log = Logger.getLogger(OperatorSDKProcessor.class.getName());
 
     private static final String FEATURE = "operator-sdk";
     private static final DotName RESOURCE_CONTROLLER = DotName
@@ -127,11 +127,13 @@ class OperatorSDKProcessor {
                         index, crdGeneration, liveReload))
                 .collect(Collectors.toList());
 
-        CRDGenerationInfo crdInfo = crdGeneration.generate(outputTarget, crdConfig, validateCustomResources);
+        // retrieve the known CRD information to make sure we always have a full view 
         var storedCRDInfos = liveReload.getContextObject(ContextStoredCRDInfos.class);
         if (storedCRDInfos == null) {
             storedCRDInfos = new ContextStoredCRDInfos();
         }
+        CRDGenerationInfo crdInfo = crdGeneration.generate(outputTarget, crdConfig, validateCustomResources,
+                storedCRDInfos.getExisting());
         storedCRDInfos.putAll(crdInfo.getCrds());
         liveReload.setContextObject(ContextStoredCRDInfos.class, storedCRDInfos); // record CRD generation info in context for future use
 

--- a/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -119,7 +119,8 @@ class OperatorSDKProcessor {
         final var index = combinedIndexBuildItem.getIndex();
         final var resourceControllers = index.getAllKnownImplementors(RESOURCE_CONTROLLER);
 
-        final var crdGeneration = new CRDGeneration(crdConfig.generate);
+        // apply should imply generate: we cannot apply if we're not generating!
+        final var crdGeneration = new CRDGeneration(crdConfig.generate || crdConfig.apply);
         final List<QuarkusControllerConfiguration> controllerConfigs = resourceControllers.stream()
                 .filter(ci -> !Modifier.isAbstract(ci.flags()))
                 .map(ci -> createControllerConfiguration(ci, additionalBeans, reflectionClasses, forcedReflectionClasses,

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
@@ -11,10 +11,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.api.ResourceController;
-import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.config.RetryConfiguration;
 import io.javaoperatorsdk.operator.api.config.Version;
+import io.quarkiverse.operatorsdk.runtime.QuarkusConfigurationService;
 import io.quarkiverse.operatorsdk.runtime.QuarkusControllerConfiguration;
 
 @Path("/operator")
@@ -23,7 +23,7 @@ public class OperatorSDKResource {
     @Inject
     Instance<ResourceController<? extends CustomResource>> controllers;
     @Inject
-    ConfigurationService configurationService;
+    QuarkusConfigurationService configurationService;
     @Inject
     Event<DelayedController.RegisterEvent> event;
 
@@ -77,9 +77,9 @@ public class OperatorSDKResource {
     }
 
     static class JSONConfiguration {
-        private final ConfigurationService conf;
+        private final QuarkusConfigurationService conf;
 
-        public JSONConfiguration(ConfigurationService conf) {
+        public JSONConfiguration(QuarkusConfigurationService conf) {
             this.conf = conf;
         }
 
@@ -104,6 +104,11 @@ public class OperatorSDKResource {
         @JsonProperty("timeout")
         public int timeout() {
             return conf.getTerminationTimeoutSeconds();
+        }
+
+        @JsonProperty("applyCRDs")
+        public boolean apply() {
+            return conf.getCRDGenerationInfo().isApplyCRDs();
         }
     }
 

--- a/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
@@ -21,6 +21,12 @@ public class OperatorSDKResourceTest {
     }
 
     @Test
+    void shouldNotApplyCRDsByDefault() {
+        given().when().get("/operator/config").then().statusCode(200).body(
+                "applyCRDs", equalTo(false));
+    }
+
+    @Test
     void shouldHavePropertiesDefinedReconciliationThreads() {
         given().when().get("/operator/config").then().statusCode(200).body(
                 "maxThreads", equalTo(10));

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>2.1.0.Final</quarkus.version>
-    <java-operator-sdk.version>1.9.2</java-operator-sdk.version>
+    <java-operator-sdk.version>1.9.3</java-operator-sdk.version>
     <kubernetes-client.version>5.6.0</kubernetes-client.version>
   </properties>
   <dependencyManagement>

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDGenerationInfo.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDGenerationInfo.java
@@ -1,47 +1,22 @@
 package io.quarkiverse.operatorsdk.runtime;
 
-import java.util.Collections;
-import java.util.Map;
+import java.util.*;
+
+import io.quarkus.runtime.annotations.RecordableConstructor;
 
 public class CRDGenerationInfo {
-    private boolean apply;
-    private boolean validate;
-    private Map<String, Map<String, CRDInfo>> crds;
+    private final boolean applyCRDs;
+    private final boolean validateCRDs;
+    private final Map<String, Map<String, CRDInfo>> crds;
+    private final Set<String> generated;
 
-    // Needed by Quarkus: class needs to be serializable
-    public CRDGenerationInfo() {
-        this(false, true, Collections.emptyMap());
-    }
-
-    public CRDGenerationInfo(boolean apply, boolean validate, Map<String, Map<String, CRDInfo>> crdInfos) {
-        this.apply = apply;
-        this.validate = validate;
-        this.crds = Collections.unmodifiableMap(crdInfos);
-    }
-
-    // Needed by Quarkus: class needs to be serializable
-    public void setApply(boolean apply) {
-        this.apply = apply;
-    }
-
-    // Needed by Quarkus: class needs to be serializable
-    public void setValidate(boolean validate) {
-        this.validate = validate;
-    }
-
-    // Needed by Quarkus: class needs to be serializable
-    public void setCrds(Map<String, Map<String, CRDInfo>> crds) {
-        this.crds = crds;
-    }
-
-    // Needed by Quarkus: if this method isn't present, state is not properly set
-    public boolean isApply() {
-        return apply;
-    }
-
-    // Needed by Quarkus: if this method isn't present, state is not properly set
-    public boolean isValidate() {
-        return validate;
+    @RecordableConstructor // constructor needs to be recordable for the class to be passed around by Quarkus
+    public CRDGenerationInfo(boolean applyCRDs, boolean validateCRDs, Map<String, Map<String, CRDInfo>> crds,
+            Set<String> generated) {
+        this.applyCRDs = applyCRDs;
+        this.validateCRDs = validateCRDs;
+        this.crds = Collections.unmodifiableMap(crds);
+        this.generated = generated;
     }
 
     // Needed by Quarkus: if this method isn't present, state is not properly set
@@ -49,8 +24,17 @@ public class CRDGenerationInfo {
         return crds;
     }
 
+    // Needed by Quarkus: if this method isn't present, state is not properly set
+    public Set<String> getGenerated() {
+        return generated;
+    }
+
     public boolean isApplyCRDs() {
-        return apply;
+        return applyCRDs;
+    }
+
+    public boolean shouldApplyCRD(String name) {
+        return generated.contains(name);
     }
 
     public Map<String, CRDInfo> getCRDInfosFor(String crdName) {
@@ -58,10 +42,6 @@ public class CRDGenerationInfo {
     }
 
     public boolean isValidateCRDs() {
-        return validate;
-    }
-
-    public boolean isEmpty() {
-        return crds.isEmpty();
+        return validateCRDs;
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDInfo.java
+++ b/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDInfo.java
@@ -2,16 +2,15 @@ package io.quarkiverse.operatorsdk.runtime;
 
 import java.util.Set;
 
+import io.quarkus.runtime.annotations.RecordableConstructor;
+
 public class CRDInfo {
-    private String crdName;
-    private String version;
-    private String filePath;
-    private Set<String> dependentClassNames;
+    private final String crdName;
+    private final String version;
+    private final String filePath;
+    private final Set<String> dependentClassNames;
 
-    // Needed by Quarkus: class needs to be serializable
-    public CRDInfo() {
-    }
-
+    @RecordableConstructor // constructor needs to be recordable for the class to be passed around by Quarkus
     public CRDInfo(String crdName, String version, String filePath, Set<String> dependentClassNames) {
         this.crdName = crdName;
         this.version = version;
@@ -33,25 +32,5 @@ public class CRDInfo {
 
     public Set<String> getDependentClassNames() {
         return this.dependentClassNames;
-    }
-
-    // Needed by Quarkus: class needs to be serializable
-    public void setCrdName(String crdName) {
-        this.crdName = crdName;
-    }
-
-    // Needed by Quarkus: class needs to be serializable
-    public void setVersion(String version) {
-        this.version = version;
-    }
-
-    // Needed by Quarkus: class needs to be serializable
-    public void setFilePath(String filePath) {
-        this.filePath = filePath;
-    }
-
-    // Needed by Quarkus: class needs to be serializable
-    public void setDependentClassNames(Set<String> dependentClassNames) {
-        this.dependentClassNames = dependentClassNames;
     }
 }


### PR DESCRIPTION
This behavior is controlled by the `quarkus.operator-sdk.crd.apply` property. When set to `true`, any change impacting the CRD will trigger a regeneration and apply the new CRD to the cluster automatically.

Fixes #11 
Fixes #12

