### PR TITLE
Rename Antora modules for consistency

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: quarkus-operator-sdk
-title: Quarkiverse Operator SDK
+title: Quarkus Operator SDK
 version: dev
 nav:
   - modules/ROOT/nav.adoc


### PR DESCRIPTION
See https://quarkiverse.github.io/quarkiverse-docs/index/index/index.html.

We decided to name the Quarkiverse extensions `Quarkus XXX` so that they can be found easily when searching for `Quarkus something`.