### PR TITLE
fix: query param remove double "?" generation

### DIFF
--- a/samples/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeController.java
+++ b/samples/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeController.java
@@ -57,7 +57,7 @@ public class JokeController implements ResourceController<JokeRequest> {
         try {
             final JokeModel fromApi = jokes.getRandom(spec.getCategory(),
                     String.join(",", Arrays.stream(spec.getExcluded()).map(ExcludedTopic::name).toArray(String[]::new)),
-                    spec.isSafe());
+                    spec.isSafe(), "single");
             status = JokeRequestStatus.from(fromApi);
             if (!status.isError()) {
                 // create the joke

--- a/samples/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeService.java
+++ b/samples/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeService.java
@@ -32,5 +32,5 @@ public interface JokeService {
     @Path("/{category}/any")
     @Produces("application/json")
     JokeModel getRandom(@PathParam Category category, @QueryParam(value = "blacklistFlags") String excluded,
-                        @QueryParam(value = "safe-mode") boolean safe, @DefaultValue("single") @QueryParam(value = "type") String type);
+            @QueryParam(value = "safe-mode") boolean safe, @DefaultValue("single") @QueryParam(value = "type") String type);
 }

--- a/samples/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeService.java
+++ b/samples/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeService.java
@@ -14,6 +14,7 @@
  */
 package io.quarkiverse.operatorsdk.samples.joke;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -28,8 +29,8 @@ import io.quarkiverse.operatorsdk.samples.joke.JokeRequestSpec.Category;
 public interface JokeService {
 
     @GET
-    @Path("/{category}/any?type=single")
+    @Path("/{category}/any")
     @Produces("application/json")
     JokeModel getRandom(@PathParam Category category, @QueryParam(value = "blacklistFlags") String excluded,
-            @QueryParam(value = "safe-mode") boolean safe);
+                        @QueryParam(value = "safe-mode") boolean safe, @DefaultValue("single") @QueryParam(value = "type") String type);
 }


### PR DESCRIPTION
fixes #143 

Use a @QueryParam for the type to avoid double "?" and "%3F" in URI:

previously was:
```
2021-11-05 16:14:45,396 DEBUG [org.apa.htt.imp.exe.MainClientExec] (EventHandler-jokecontroller) Executing request GET /joke/Any/any%3Ftype=single?blacklistFlags=nsfw%2Cracist%2Csexist&safe-mode=false HTTP/1.1
``` 

now:
```
DEBUG [org.apa.htt.wire] (EventHandler-jokecontroller) http-outgoing-0 >> "GET /joke/Any/any?blacklistFlags=nsfw%2Cracist%2Csexist&safe-mode=false&type=single HTTP/1.1[\r][\n]"
```
