### PR TITLE
Run it tests in native mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,5 +53,5 @@ jobs:
           key: maven-repo-${{ runner.os }}-${{ steps.get-date.outputs.date }}
 
       - name: Build with Maven
-        run: mvn -B formatter:validate verify --file pom.xml
+        run: mvn -B formatter:validate verify -Dnative --file pom.xml
 


### PR DESCRIPTION
This will allow to discover errors like https://github.com/quarkiverse/quarkus-operator-sdk/issues/175

I pushed first without the update to 2.6.1 that fix the VersionInfo serialization error. Build should failed.