### PR TITLE
feat: make it possible to not automatically start the operator

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -119,7 +119,7 @@ class OperatorSDKProcessor {
                 .configurationServiceSupplier(serviceBuildItem.getVersion(),
                         serviceBuildItem.getControllerConfigs(),
                         generatedCRDs.getCRDGenerationInfo(),
-                        runTimeConfiguration);
+                        runTimeConfiguration, buildTimeConfiguration);
         syntheticBeanBuildItemBuildProducer.produce(
                 SyntheticBeanBuildItem.configure(QuarkusConfigurationService.class)
                         .scope(Singleton.class)
@@ -188,6 +188,7 @@ class OperatorSDKProcessor {
     }
 
     @BuildStep(onlyIf = IsRBACEnabled.class)
+    @SuppressWarnings("unchecked")
     public void addRBACForResources(BuildProducer<DecoratorBuildItem> decorators,
             ConfigurationServiceBuildItem configurations) {
 
@@ -213,6 +214,7 @@ class OperatorSDKProcessor {
         return mc.checkCast(mc.invokeInterfaceMethod(getMethod, operatorInstance), handleClass);
     }
 
+    @SuppressWarnings("unchecked")
     private Optional<QuarkusControllerConfiguration> createControllerConfiguration(
             ClassInfo info,
             BuildProducer<AdditionalBeanBuildItem> additionalBeans,

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/AppEventListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/AppEventListener.java
@@ -28,10 +28,14 @@ public class AppEventListener {
             log.info("Quarkus Java Operator SDK extension {} (commit: {}{}) built on {}", version.getExtensionVersion(),
                     version.getExtensionCommit(), branch, version.getExtensionBuildTime());
         }
-        if (!operator.getControllers().isEmpty()) {
-            operator.start();
+        if (configurationService.shouldStartOperator()) {
+            if (!operator.getControllers().isEmpty()) {
+                operator.start();
+            } else {
+                log.warn("No Reconciler implementation was found so the Operator was not started.");
+            }
         } else {
-            log.warn("No Reconciler implementation was found so the Operator was not started.");
+            log.warn("Operator was configured not to start automatically, call the start method to start it.");
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
@@ -53,4 +53,10 @@ public class BuildTimeOperatorConfiguration {
      */
     @ConfigItem(defaultValue = "false")
     public Boolean disableRbacGeneration;
+
+    /**
+     * Whether the operator should be automatically started or not. Mostly useful for testing scenarios.
+     */
+    @ConfigItem(defaultValue = "true")
+    public Boolean startOperator;
 }

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
@@ -14,10 +14,11 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class ConfigurationServiceRecorder {
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public Supplier<QuarkusConfigurationService> configurationServiceSupplier(Version version,
             Map<String, QuarkusControllerConfiguration> configurations,
-            CRDGenerationInfo crdInfo, RunTimeOperatorConfiguration runTimeConfiguration) {
+            CRDGenerationInfo crdInfo, RunTimeOperatorConfiguration runTimeConfiguration,
+            BuildTimeOperatorConfiguration buildTimeConfiguration) {
         final var maxThreads = runTimeConfiguration.concurrentReconciliationThreads
                 .orElse(ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
         final var timeout = runTimeConfiguration.terminationTimeoutSeconds
@@ -46,6 +47,7 @@ public class ConfigurationServiceRecorder {
                 maxThreads,
                 timeout,
                 Arc.container().instance(ObjectMapper.class).get(),
-                Arc.container().instance(Metrics.class).get());
+                Arc.container().instance(Metrics.class).get(),
+                buildTimeConfiguration.startOperator);
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
@@ -32,18 +32,20 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
     private final int terminationTimeout;
     private final Map<String, String> reconcilerClassToName;
     private final Metrics metrics;
+    private final boolean startOperator;
 
+    @SuppressWarnings({ "rawtypes", "unchecked" })
     public QuarkusConfigurationService(
             Version version,
             Collection<QuarkusControllerConfiguration> configurations,
             KubernetesClient client,
             CRDGenerationInfo crdInfo, int maxThreads,
-            int timeout, ObjectMapper mapper, Metrics metrics) {
+            int timeout, ObjectMapper mapper, Metrics metrics, boolean startOperator) {
         super(version);
+        this.startOperator = startOperator;
         this.client = client;
         this.cloner = new Cloner() {
             @Override
-            @SuppressWarnings("unchecked")
             public <R extends HasMetadata> R clone(R r) {
                 try {
                     return (R) mapper.readValue(mapper.writeValueAsString(r), r.getClass());
@@ -138,5 +140,9 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
 
     KubernetesClient getClient() {
         return client;
+    }
+
+    boolean shouldStartOperator() {
+        return startOperator;
     }
 }


### PR DESCRIPTION
The configuration option is `quarkus.operator-sdk.start-operator=false`.
Fixes #207
