### PR TITLE
feat: initial support for -Dquickly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,5 +33,21 @@
         <module>integration-tests</module>
       </modules>
     </profile>
+    <profile>
+      <id>quick-build</id>
+      <activation>
+        <property>
+          <name>quickly</name>
+        </property>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+        <skipITs>true</skipITs>
+        <skipDocs>true</skipDocs>
+      </properties>
+      <build>
+        <defaultGoal>clean install</defaultGoal>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
Fixes #224, at least partially. More complete fix would probably need to
disable building the `integration-tests` module altogether to avoid
Quarkus building the test reconcilers.
