### PR TITLE
improvements

### DIFF
--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleGenerator.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleGenerator.java
@@ -14,7 +14,6 @@ import io.quarkiverse.operatorsdk.bundle.deployment.builders.ManifestsBuilder;
 import io.quarkiverse.operatorsdk.bundle.runtime.BundleGenerationConfiguration;
 import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadataHolder;
 import io.quarkiverse.operatorsdk.runtime.BuildTimeOperatorConfiguration;
-import io.quarkus.arc.impl.Sets;
 import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 
 public class BundleGenerator {
@@ -45,7 +44,7 @@ public class BundleGenerator {
         final var builders = new ConcurrentHashMap<String, Set<ManifestsBuilder>>(7);
         return info.values().parallelStream()
                 .flatMap(cri -> builders.computeIfAbsent(cri.getCsvGroupName(),
-                        s -> Sets.of(new CsvManifestsBuilder(cri, csvMetadata),
+                        s -> Set.of(new CsvManifestsBuilder(cri, csvMetadata),
                                 new AnnotationsManifestsBuilder(cri, labels),
                                 new BundleDockerfileManifestsBuilder(cri, labels)))
                         .stream())

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleGenerator.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleGenerator.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import io.quarkiverse.operatorsdk.bundle.deployment.builders.AnnotationsManifestsBuilder;
 import io.quarkiverse.operatorsdk.bundle.deployment.builders.BundleDockerfileManifestsBuilder;

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleGenerator.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleGenerator.java
@@ -51,7 +51,7 @@ public class BundleGenerator {
                 .collect(Collectors.toSet());
     }
 
-    private static final Map<String, String> generateBundleLabels(
+    private static Map<String, String> generateBundleLabels(
             ApplicationInfoBuildItem applicationConfiguration,
             BundleGenerationConfiguration bundleConfiguration,
             BuildTimeOperatorConfiguration operatorConfiguration) {
@@ -59,8 +59,7 @@ public class BundleGenerator {
         for (String version : operatorConfiguration.crd.versions) {
             values.put(join(PREFIX_ANNOTATION, CHANNEL, DEFAULT, version),
                     bundleConfiguration.defaultChannel.orElse(bundleConfiguration.channels.get(0)));
-            values.put(join(PREFIX_ANNOTATION, CHANNELS, version),
-                    bundleConfiguration.channels.stream().collect(Collectors.joining(COMMA)));
+            values.put(join(PREFIX_ANNOTATION, CHANNELS, version), String.join(COMMA, bundleConfiguration.channels));
             values.put(join(PREFIX_ANNOTATION, MANIFESTS, version), MANIFESTS + SLASH);
             values.put(join(PREFIX_ANNOTATION, MEDIA_TYPE, version), REGISTRY_PLUS + version);
             values.put(join(PREFIX_ANNOTATION, METADATA, version), METADATA + SLASH);
@@ -71,7 +70,7 @@ public class BundleGenerator {
         return values;
     }
 
-    private static final String join(String... elements) {
-        return Stream.of(elements).collect(Collectors.joining(DOT));
+    private static String join(String... elements) {
+        return String.join(DOT, elements);
     }
 }

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
@@ -136,7 +136,6 @@ public class BundleProcessor {
 
                                         if (r instanceof Deployment) {
                                             deployments.add((Deployment) r);
-                                            return;
                                         }
                                     });
                                 });
@@ -169,7 +168,7 @@ public class BundleProcessor {
                         });
                 doneGeneratingCSV.produce(new GeneratedBundleBuildItem());
             } catch (Exception e) {
-                log.infov(e, "Couldn't generate CSV:");
+                log.infov(e, "Couldn't generate bundle:");
             }
         }
     }

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
@@ -230,7 +230,7 @@ public class BundleProcessor {
         }
 
         final var installModesField = csvMetadata.value("installModes");
-        CSVMetadataHolder.InstallMode[] installModes = null;
+        CSVMetadataHolder.InstallMode[] installModes;
         if (installModesField != null) {
             final var installModesAnn = installModesField.asNestedArray();
             installModes = new CSVMetadataHolder.InstallMode[installModesAnn.length];
@@ -246,7 +246,7 @@ public class BundleProcessor {
         }
 
         final var permissionsField = csvMetadata.value("permissionRules");
-        CSVMetadataHolder.PermissionRule[] permissionRules = null;
+        CSVMetadataHolder.PermissionRule[] permissionRules;
         if (permissionsField != null) {
             final var permissionsAnn = permissionsField.asNestedArray();
             permissionRules = new CSVMetadataHolder.PermissionRule[permissionsAnn.length];

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
@@ -148,7 +148,7 @@ public class BundleProcessor {
                         generatedCSVs.produce(
                                 new GeneratedFileSystemResourceBuildItem(
                                         Path.of(BUNDLE).resolve(fileName).toString(),
-                                        manifestBuilder.getYAMLData(serviceAccounts, clusterRoleBindings, clusterRoles,
+                                        manifestBuilder.getManifestData(serviceAccounts, clusterRoleBindings, clusterRoles,
                                                 roleBindings, roles, deployments)));
                         log.infov("Generating CSV for {0} controller -> {1}", manifestBuilder.getControllerName(),
                                 outputDir.resolve(fileName));

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/AnnotationsManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/AnnotationsManifestsBuilder.java
@@ -33,7 +33,7 @@ public class AnnotationsManifestsBuilder extends ManifestsBuilder {
     }
 
     @Override
-    public byte[] getYAMLData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
+    public byte[] getManifestData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
             List<ClusterRole> clusterRoles, List<RoleBinding> roleBindings, List<Role> roles, List<Deployment> deployments)
             throws IOException {
 

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/BundleDockerfileManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/BundleDockerfileManifestsBuilder.java
@@ -39,7 +39,7 @@ public class BundleDockerfileManifestsBuilder extends ManifestsBuilder {
 
         for (Map.Entry<String, String> label : bundleLabels.entrySet()) {
             sb.append("LABEL ").append(label.getKey()).append("=").append(label.getValue())
-                .append(lineSeparator);
+                    .append(lineSeparator);
         }
 
         sb.append("COPY manifests /manifests/").append(lineSeparator);

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/BundleDockerfileManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/BundleDockerfileManifestsBuilder.java
@@ -34,14 +34,16 @@ public class BundleDockerfileManifestsBuilder extends ManifestsBuilder {
     public byte[] getManifestData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
             List<ClusterRole> clusterRoles, List<RoleBinding> roleBindings, List<Role> roles, List<Deployment> deployments) {
         StringBuilder sb = new StringBuilder();
-        sb.append("FROM scratch" + System.lineSeparator());
+        final var lineSeparator = System.lineSeparator();
+        sb.append("FROM scratch").append(lineSeparator);
 
         for (Map.Entry<String, String> label : bundleLabels.entrySet()) {
-            sb.append("LABEL " + label.getKey() + "=" + label.getValue() + System.lineSeparator());
+            sb.append("LABEL ").append(label.getKey()).append("=").append(label.getValue())
+                .append(lineSeparator);
         }
 
-        sb.append("COPY manifests /manifests/" + System.lineSeparator());
-        sb.append("COPY metadata /metadata/" + System.lineSeparator());
+        sb.append("COPY manifests /manifests/").append(lineSeparator);
+        sb.append("COPY metadata /metadata/").append(lineSeparator);
 
         return sb.toString().getBytes(StandardCharsets.UTF_8);
     }

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/BundleDockerfileManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/BundleDockerfileManifestsBuilder.java
@@ -31,7 +31,7 @@ public class BundleDockerfileManifestsBuilder extends ManifestsBuilder {
     }
 
     @Override
-    public byte[] getYAMLData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
+    public byte[] getManifestData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
             List<ClusterRole> clusterRoles, List<RoleBinding> roleBindings, List<Role> roles, List<Deployment> deployments) {
         StringBuilder sb = new StringBuilder();
         sb.append("FROM scratch" + System.lineSeparator());

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
@@ -85,7 +85,7 @@ public class CsvManifestsBuilder extends ManifestsBuilder {
             }
         }
 
-        if (metadata.installModes == null || metadata.maintainers.length == 0) {
+        if (metadata.installModes == null || metadata.installModes.length == 0) {
             csvSpecBuilder.addNewInstallMode(true, DEFAULT_INSTALL_MODE);
         } else {
             for (CSVMetadataHolder.InstallMode installMode : metadata.installModes) {

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
@@ -107,7 +107,7 @@ public class CsvManifestsBuilder extends ManifestsBuilder {
         return Path.of(MANIFESTS, csvGroupName + ".csv.yml");
     }
 
-    public byte[] getYAMLData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
+    public byte[] getManifestData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
             List<ClusterRole> clusterRoles, List<RoleBinding> roleBindings, List<Role> roles,
             List<Deployment> deployments) throws IOException {
         final var csvSpecBuilder = csvBuilder

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
@@ -161,8 +161,7 @@ public class CsvManifestsBuilder extends ManifestsBuilder {
         Map<String, List<PolicyRule>> customPermissionRules = new HashMap<>();
         if (metadata.permissionRules != null) {
             for (CSVMetadataHolder.PermissionRule permissionRule : metadata.permissionRules) {
-                String serviceAccountName = defaultIfEmpty(permissionRule.serviceAccountName,
-                        defaultServiceAccountName);
+                String serviceAccountName = defaultIfEmpty(permissionRule.serviceAccountName, defaultServiceAccountName);
                 List<PolicyRule> customRulesByServiceAccount = customPermissionRules.computeIfAbsent(serviceAccountName,
                         k -> new LinkedList<>());
 

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/ManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/ManifestsBuilder.java
@@ -40,7 +40,7 @@ public abstract class ManifestsBuilder {
 
     public abstract Path getFileName();
 
-    public abstract byte[] getYAMLData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
+    public abstract byte[] getManifestData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
             List<ClusterRole> clusterRoles, List<RoleBinding> roleBindings, List<Role> roles,
             List<Deployment> deployments) throws IOException;
 

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/ManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/ManifestsBuilder.java
@@ -31,11 +31,9 @@ public abstract class ManifestsBuilder {
     }
 
     private final String controllerName;
-    private final String csvGroupName;
 
     public ManifestsBuilder(AugmentedResourceInfo cri) {
         controllerName = cri.getControllerName();
-        csvGroupName = cri.getCsvGroupName();
     }
 
     public abstract Path getFileName();

--- a/bundle-generator/runtime/src/main/java/io/quarkiverse/operatorsdk/bundle/runtime/CSVMetadata.java
+++ b/bundle-generator/runtime/src/main/java/io/quarkiverse/operatorsdk/bundle/runtime/CSVMetadata.java
@@ -7,6 +7,7 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE })
+@SuppressWarnings("unused")
 public @interface CSVMetadata {
     String name() default "";
 

--- a/samples/mysql-schema/pom.xml
+++ b/samples/mysql-schema/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+  xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
@@ -42,6 +44,10 @@
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-mysql</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/samples/mysql-schema/pom.xml
+++ b/samples/mysql-schema/pom.xml
@@ -31,10 +31,6 @@
       <artifactId>quarkus-container-image-jib</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>io.quarkiverse.operatorsdk</groupId>
       <artifactId>quarkus-operator-sdk-bundle-generator-deployment</artifactId>
       <scope>provided</scope>


### PR DESCRIPTION
- refactor: use java.util.Set operation instead of Sets from Arc
- refactor: use String.join instead of stream operations
- refactor: rename getYAMLData to more appropriate getManifestData
- refactor: remove unneeded field
- refactor: use append instead of concatenation
- fix: remove unused warnings
- fix: wrong field was used
- refactor: minor improvements
- refactor: remove dependency on commons-lang3 Fixes #257
- fix: logging
