### PR TITLE
test(mysql-schema): refactor with standalone dependent resource

### DIFF
--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
@@ -1,8 +1,5 @@
 package io.quarkiverse.operatorsdk.it;
 
-import io.quarkiverse.operatorsdk.runtime.QuarkusDependentResourceSpec;
-import io.quarkiverse.operatorsdk.runtime.QuarkusKubernetesDependentResourceConfig;
-import io.quarkus.runtime.annotations.RegisterForReflection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -25,9 +22,10 @@ import io.javaoperatorsdk.operator.api.config.RetryConfiguration;
 import io.javaoperatorsdk.operator.api.config.Version;
 import io.javaoperatorsdk.operator.api.config.dependent.DependentResourceSpec;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
-import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResourceConfig;
 import io.quarkiverse.operatorsdk.runtime.QuarkusConfigurationService;
 import io.quarkiverse.operatorsdk.runtime.QuarkusControllerConfiguration;
+import io.quarkiverse.operatorsdk.runtime.QuarkusKubernetesDependentResourceConfig;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 @Path("/operator")
 public class OperatorSDKResource {

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/ResourcePollerConfig.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/ResourcePollerConfig.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
+
+public class ResourcePollerConfig {
+    private final int pollPeriod;
+
+    public ResourcePollerConfig(int pollPeriod) {
+        this.pollPeriod = pollPeriod;
+    }
+
+    public int getPollPeriod() {
+        return pollPeriod;
+    }
+}

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaDependentResource.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaDependentResource.java
@@ -1,0 +1,91 @@
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
+
+import static io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentResource.MYSQL_SECRET_PASSWORD;
+import static io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentResource.MYSQL_SECRET_USERNAME;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Creator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceConfigurator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
+import io.javaoperatorsdk.operator.processing.dependent.external.PerResourcePollingDependentResource;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
+
+@ApplicationScoped
+public class SchemaDependentResource
+        extends PerResourcePollingDependentResource<Schema, MySQLSchema>
+        implements EventSourceProvider<MySQLSchema>,
+        DependentResourceConfigurator<ResourcePollerConfig>,
+        Creator<Schema, MySQLSchema>,
+        Deleter<MySQLSchema> {
+
+    private static final Logger log = LoggerFactory.getLogger(SchemaDependentResource.class);
+
+    @Inject
+    SchemaService schemaService;
+
+    @Override
+    public void configureWith(ResourcePollerConfig config) {
+        setPollingPeriod(config.getPollPeriod());
+    }
+
+    @Override
+    public Schema desired(MySQLSchema primary, Context<MySQLSchema> context) {
+        return new Schema(primary.getMetadata().getName(), primary.getSpec().getEncoding());
+    }
+
+    @Override
+    public Schema create(Schema target, MySQLSchema mySQLSchema, Context<MySQLSchema> context) {
+        try (Connection connection = schemaService.getConnection()) {
+            Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
+            var username = decode(secret.getData().get(MYSQL_SECRET_USERNAME));
+            var password = decode(secret.getData().get(MYSQL_SECRET_PASSWORD));
+            return schemaService.createSchemaAndRelatedUser(
+                    connection,
+                    target.getName(),
+                    target.getCharacterSet(), username, password);
+        } catch (SQLException e) {
+            log.error("Error while creating Schema", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void delete(MySQLSchema primary, Context<MySQLSchema> context) {
+        try (Connection connection = schemaService.getConnection()) {
+            var userName = primary.getStatus() != null ? primary.getStatus().getUserName() : null;
+            schemaService.deleteSchemaAndRelatedUser(connection, primary.getMetadata().getName(),
+                    userName);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error while trying to delete Schema", e);
+        }
+    }
+
+    @Override
+    public Optional<Schema> fetchResource(MySQLSchema primaryResource) {
+        try (Connection connection = schemaService.getConnection()) {
+            var schema = schemaService.getSchema(connection, primaryResource.getMetadata().getName()).orElse(null);
+            return Optional.ofNullable(schema);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error while trying read Schema", e);
+        }
+    }
+
+    private static String decode(String value) {
+        return new String(Base64.getDecoder().decode(value.getBytes()));
+    }
+}

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaPollingResourceFetcher.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaPollingResourceFetcher.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.operatorsdk.samples.mysqlschema;
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
 
 import java.util.Optional;
 
@@ -6,18 +6,20 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import io.javaoperatorsdk.operator.processing.event.source.polling.PerResourcePollingEventSource;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
 
 @ApplicationScoped
-public class SchemaPollingResourceSupplier
+public class SchemaPollingResourceFetcher
         implements PerResourcePollingEventSource.ResourceFetcher<Schema, MySQLSchema> {
 
     @Inject
     SchemaService schemaService;
 
     @Override
-    public Optional<Schema> fetchResource(MySQLSchema primaryResource) {
-        return schemaService.getSchema(primaryResource.getMetadata().getName());
+    public Optional<Schema> fetchResource(MySQLSchema resource) {
+        return schemaService.getSchema(resource.getMetadata().getName());
     }
+
 }

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
@@ -1,0 +1,76 @@
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
+
+import java.util.Base64;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Creator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Matcher.Result;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
+
+@ApplicationScoped
+public class SecretDependentResource extends KubernetesDependentResource<Secret, MySQLSchema>
+        implements PrimaryToSecondaryMapper<MySQLSchema>, Creator<Secret, MySQLSchema> {
+
+    public static final String SECRET_FORMAT = "%s-secret";
+    public static final String USERNAME_FORMAT = "%s-user";
+    public static final String MYSQL_SECRET_USERNAME = "mysql.secret.user.name";
+    public static final String MYSQL_SECRET_PASSWORD = "mysql.secret.user.password";
+
+    private static String encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes());
+    }
+
+    @Override
+    protected Secret desired(MySQLSchema schema, Context<MySQLSchema> context) {
+        final var password = RandomStringUtils
+                .randomAlphanumeric(16); // NOSONAR: we don't need cryptographically-strong randomness here
+        final var name = schema.getMetadata().getName();
+        final var secretName = getSecretName(name);
+        final var userName = String.format(USERNAME_FORMAT, name);
+
+        return new SecretBuilder()
+                .withNewMetadata()
+                .withName(secretName)
+                .withNamespace(schema.getMetadata().getNamespace())
+                .endMetadata()
+                .addToData(MYSQL_SECRET_USERNAME, encode(userName))
+                .addToData(MYSQL_SECRET_PASSWORD, encode(password))
+                .build();
+    }
+
+    private String getSecretName(String name) {
+        return String.format(SECRET_FORMAT, name);
+    }
+
+    @Override
+    public Result<Secret> match(Secret actual, MySQLSchema primary, Context context) {
+        final var desiredSecretName = getSecretName(primary.getMetadata().getName());
+        return Result.nonComputed(actual.getMetadata().getName().equals(desiredSecretName));
+    }
+
+    @Override
+    public ResourceID associatedSecondaryID(MySQLSchema primary) {
+        return new ResourceID(
+                String.format(SECRET_FORMAT, primary.getMetadata().getName()),
+                primary.getMetadata().getNamespace());
+    }
+
+    @Override
+    protected Class<Secret> resourceType() {
+        java.lang.reflect.Type type = getClass().getGenericSuperclass();
+        if (type instanceof Class<?>) {
+            type = ((Class<?>) type).getGenericSuperclass();
+        }
+
+        return (Class<Secret>) ((java.lang.reflect.ParameterizedType) type).getActualTypeArguments()[0];
+    }
+}

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/SchemaService.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/SchemaService.java
@@ -30,7 +30,7 @@ public class SchemaService {
         }
     }
 
-    public void createSchemaAndRelatedUser(Connection connection, String schemaName,
+    public Schema createSchemaAndRelatedUser(Connection connection, String schemaName,
             String encoding,
             String userName,
             String password) {
@@ -50,6 +50,8 @@ public class SchemaService {
                 statement.execute(
                         format("GRANT ALL ON `%1$s`.* TO '%2$s'", schemaName, userName));
             }
+
+            return new Schema(schemaName, encoding);
         } catch (SQLException e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
First step to raise issue with DepedentResource integration in Quarkus.

I tried to use the annotation syntax but JOSDK  `DependentResourceManager` is not CDI aware, so this is only using dependent resource in standalone mode.