### PR TITLE
fix: use josdk 2.1.2-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <quarkus.version>2.7.4.Final</quarkus.version>
-    <java-operator-sdk.version>2.1.1</java-operator-sdk.version>
+    <java-operator-sdk.version>2.1.2-SNAPSHOT</java-operator-sdk.version>
     <kubernetes-client.version>5.11.2</kubernetes-client.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
The goal here is to make the snapshot version available to test with quarkus extension