### PR TITLE
test(mysql-schema): refactor with standalone dependent resource

### DIFF
--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaReconciler.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaReconciler.java
@@ -1,104 +1,45 @@
 package io.quarkiverse.operatorsdk.samples.mysqlschema;
 
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.Base64;
-import java.util.List;
+import static io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentResource.MYSQL_SECRET_USERNAME;
 
 import javax.inject.Inject;
 
-import org.apache.commons.lang3.RandomStringUtils;
-
-import io.fabric8.kubernetes.api.model.OwnerReference;
 import io.fabric8.kubernetes.api.model.Secret;
-import io.fabric8.kubernetes.api.model.SecretBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
-import io.javaoperatorsdk.operator.api.reconciler.DeleteControl;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusHandler;
 import io.javaoperatorsdk.operator.api.reconciler.ErrorStatusUpdateControl;
-import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
-import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
-import io.javaoperatorsdk.operator.processing.event.source.EventSource;
-import io.javaoperatorsdk.operator.processing.event.source.polling.PerResourcePollingEventSource;
-import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SchemaDependentResource;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentResource;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
 import io.quarkus.logging.Log;
 
-@ControllerConfiguration
+@ControllerConfiguration(dependents = {
+        @Dependent(type = SecretDependentResource.class),
+        @Dependent(type = SchemaDependentResource.class)
+})
 public class MySQLSchemaReconciler
-        implements Reconciler<MySQLSchema>, ErrorStatusHandler<MySQLSchema>, EventSourceInitializer<MySQLSchema> {
-    public static final String SECRET_FORMAT = "%s-secret";
-    public static final String USERNAME_FORMAT = "%s-user";
-    public static final int POLL_PERIOD = 500;
-
-    @Inject
-    KubernetesClient kubernetesClient;
-
-    @Inject
-    SchemaPollingResourceSupplier schemaPollingResourceSupplier;
+        implements Reconciler<MySQLSchema>, ErrorStatusHandler<MySQLSchema> {
 
     @Inject
     SchemaService schemaService;
 
     @Override
-    public List<EventSource> prepareEventSources(EventSourceContext<MySQLSchema> context) {
-        return List.of(new PerResourcePollingEventSource<>(schemaPollingResourceSupplier, context.getPrimaryCache(),
-                POLL_PERIOD, Schema.class));
-    }
-
-    @Override
-    public UpdateControl<MySQLSchema> reconcile(MySQLSchema schema, Context<MySQLSchema> context) {
-        Log.infof("Reconciling MySQLSchema with name: %s", schema.getMetadata().getName());
-        var dbSchema = context.getSecondaryResource(Schema.class);
-        Log.debugf("Schema: %s found for: %s ", dbSchema, schema.getMetadata().getName());
-        try (Connection connection = schemaService.getConnection()) {
-            if (dbSchema.isEmpty()) {
-                Log.debugf("Creating Schema and related resources for: %s", schema.getMetadata().getName());
-                var schemaName = schema.getMetadata().getName();
-                String password = RandomStringUtils.random(16);
-                String secretName = String.format(SECRET_FORMAT, schemaName);
-                String userName = String.format(USERNAME_FORMAT, schemaName);
-
-                schemaService.createSchemaAndRelatedUser(connection, schemaName,
-                        schema.getSpec().getEncoding(), userName, password);
-                createSecret(schema, password, secretName, userName);
-                updateStatusPojo(schema, secretName, userName);
-                Log.infof("Schema %s created - updating CR status", schema.getMetadata().getName());
-                return UpdateControl.updateStatus(schema);
-            } else {
-                Log.debugf("No update on MySQLSchema with name: %s", schema.getMetadata().getName());
-                return UpdateControl.noUpdate();
-            }
-        } catch (SQLException e) {
-            Log.error("Error while creating Schema", e);
-
-            throw new IllegalStateException(e);
-        }
-    }
-
-    @Override
-    public DeleteControl cleanup(MySQLSchema schema, Context context) {
-        Log.infof("Cleaning up for: %s", schema.getMetadata().getName());
-        try (Connection connection = schemaService.getConnection()) {
-            var dbSchema = schemaService.getSchema(connection, schema.getMetadata().getName());
-            if (dbSchema.isPresent()) {
-                var userName = schema.getStatus() != null ? schema.getStatus().getUserName() : null;
-                schemaService.deleteSchemaAndRelatedUser(connection, schema.getMetadata().getName(),
-                        userName);
-            } else {
-                Log.infof(
-                        "Delete event ignored for schema '%s', real schema doesn't exist",
-                        schema.getMetadata().getName());
-            }
-            return DeleteControl.defaultDelete();
-        } catch (SQLException e) {
-            Log.error("Error while trying to delete Schema", e);
-            return DeleteControl.noFinalizerRemoval();
-        }
+    public UpdateControl<MySQLSchema> reconcile(MySQLSchema resource, Context<MySQLSchema> context) {
+        // we only need to update the status if we just built the schema, i.e. when it's present in the
+        // context
+        Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
+        SchemaDependentResource schemaDependentResource = context.managedDependentResourceContext()
+                .getDependentResource(SchemaDependentResource.class);
+        return schemaDependentResource.fetchResource(resource).map(s -> {
+            updateStatusPojo(resource, secret.getMetadata().getName(),
+                    secret.getData().get(MYSQL_SECRET_USERNAME));
+            Log.infof("Schema %s created - updating CR status", resource.getMetadata().getName());
+            return UpdateControl.updateStatus(resource);
+        }).orElse(UpdateControl.noUpdate());
     }
 
     @Override
@@ -121,31 +62,5 @@ public class MySQLSchemaReconciler
         status.setSecretName(secretName);
         status.setStatus("CREATED");
         schema.setStatus(status);
-    }
-
-    private void createSecret(MySQLSchema schema, String password, String secretName,
-            String userName) {
-
-        var currentSecret = kubernetesClient.secrets().inNamespace(schema.getMetadata().getNamespace())
-                .withName(secretName).get();
-        if (currentSecret != null) {
-            return;
-        }
-        Secret credentialsSecret = new SecretBuilder()
-                .withNewMetadata()
-                .withName(secretName)
-                .withOwnerReferences(new OwnerReference("mysql.sample.javaoperatorsdk/v1",
-                        false, false, "MySQLSchema",
-                        schema.getMetadata().getName(), schema.getMetadata().getUid()))
-                .endMetadata()
-                .addToData(
-                        "MYSQL_USERNAME", Base64.getEncoder().encodeToString(userName.getBytes()))
-                .addToData(
-                        "MYSQL_PASSWORD", Base64.getEncoder().encodeToString(password.getBytes()))
-                .build();
-        this.kubernetesClient
-                .secrets()
-                .inNamespace(schema.getMetadata().getNamespace())
-                .create(credentialsSecret);
     }
 }

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/ResourcePollerConfig.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/ResourcePollerConfig.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
+
+public class ResourcePollerConfig {
+    private final int pollPeriod;
+
+    public ResourcePollerConfig(int pollPeriod) {
+        this.pollPeriod = pollPeriod;
+    }
+
+    public int getPollPeriod() {
+        return pollPeriod;
+    }
+}

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaDependentResource.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaDependentResource.java
@@ -1,0 +1,95 @@
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
+
+import static io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentResource.MYSQL_SECRET_PASSWORD;
+import static io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentResource.MYSQL_SECRET_USERNAME;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Creator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResourceConfigurator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.EventSourceProvider;
+import io.javaoperatorsdk.operator.processing.dependent.external.PerResourcePollingDependentResource;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
+
+@ApplicationScoped
+public class SchemaDependentResource
+        extends PerResourcePollingDependentResource<Schema, MySQLSchema>
+        implements EventSourceProvider<MySQLSchema>,
+        DependentResourceConfigurator<ResourcePollerConfig>,
+        Creator<Schema, MySQLSchema>,
+        Deleter<MySQLSchema> {
+
+    private static final Logger log = LoggerFactory.getLogger(SchemaDependentResource.class);
+
+    @Inject
+    SchemaService schemaService;
+
+    public SchemaDependentResource() {
+        super(Schema.class);
+    }
+
+    @Override
+    public void configureWith(ResourcePollerConfig config) {
+        setPollingPeriod(config.getPollPeriod());
+    }
+
+    @Override
+    public Schema desired(MySQLSchema primary, Context<MySQLSchema> context) {
+        return new Schema(primary.getMetadata().getName(), primary.getSpec().getEncoding());
+    }
+
+    @Override
+    public Schema create(Schema target, MySQLSchema mySQLSchema, Context<MySQLSchema> context) {
+        try (Connection connection = schemaService.getConnection()) {
+            Secret secret = context.getSecondaryResource(Secret.class).orElseThrow();
+            var username = decode(secret.getData().get(MYSQL_SECRET_USERNAME));
+            var password = decode(secret.getData().get(MYSQL_SECRET_PASSWORD));
+            return schemaService.createSchemaAndRelatedUser(
+                    connection,
+                    target.getName(),
+                    target.getCharacterSet(), username, password);
+        } catch (SQLException e) {
+            log.error("Error while creating Schema", e);
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void delete(MySQLSchema primary, Context<MySQLSchema> context) {
+        try (Connection connection = schemaService.getConnection()) {
+            var userName = primary.getStatus() != null ? primary.getStatus().getUserName() : null;
+            schemaService.deleteSchemaAndRelatedUser(connection, primary.getMetadata().getName(),
+                    userName);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error while trying to delete Schema", e);
+        }
+    }
+
+    @Override
+    public Optional<Schema> fetchResource(MySQLSchema primaryResource) {
+        try (Connection connection = schemaService.getConnection()) {
+            var schema = schemaService.getSchema(connection, primaryResource.getMetadata().getName()).orElse(null);
+            return Optional.ofNullable(schema);
+        } catch (SQLException e) {
+            throw new RuntimeException("Error while trying read Schema", e);
+        }
+    }
+
+    private static String decode(String value) {
+        return new String(Base64.getDecoder().decode(value.getBytes()));
+    }
+}

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaPollingResourceFetcher.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaPollingResourceFetcher.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.operatorsdk.samples.mysqlschema;
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
 
 import java.util.Optional;
 
@@ -6,18 +6,20 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import io.javaoperatorsdk.operator.processing.event.source.polling.PerResourcePollingEventSource;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
 
 @ApplicationScoped
-public class SchemaPollingResourceSupplier
+public class SchemaPollingResourceFetcher
         implements PerResourcePollingEventSource.ResourceFetcher<Schema, MySQLSchema> {
 
     @Inject
     SchemaService schemaService;
 
     @Override
-    public Optional<Schema> fetchResource(MySQLSchema primaryResource) {
-        return schemaService.getSchema(primaryResource.getMetadata().getName());
+    public Optional<Schema> fetchResource(MySQLSchema resource) {
+        return schemaService.getSchema(resource.getMetadata().getName());
     }
+
 }

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
+
+import java.util.Base64;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.commons.lang3.RandomStringUtils;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.SecretBuilder;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Creator;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Matcher.Result;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.event.ResourceID;
+import io.javaoperatorsdk.operator.processing.event.source.PrimaryToSecondaryMapper;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
+
+@ApplicationScoped
+public class SecretDependentResource extends KubernetesDependentResource<Secret, MySQLSchema>
+        implements PrimaryToSecondaryMapper<MySQLSchema>, Creator<Secret, MySQLSchema> {
+
+    public static final String SECRET_FORMAT = "%s-secret";
+    public static final String USERNAME_FORMAT = "%s-user";
+    public static final String MYSQL_SECRET_USERNAME = "mysql.secret.user.name";
+    public static final String MYSQL_SECRET_PASSWORD = "mysql.secret.user.password";
+
+    public SecretDependentResource() {
+        super(Secret.class);
+    }
+
+    private static String encode(String value) {
+        return Base64.getEncoder().encodeToString(value.getBytes());
+    }
+
+    @Override
+    protected Secret desired(MySQLSchema schema, Context<MySQLSchema> context) {
+        final var password = RandomStringUtils
+                .randomAlphanumeric(16); // NOSONAR: we don't need cryptographically-strong randomness here
+        final var name = schema.getMetadata().getName();
+        final var secretName = getSecretName(name);
+        final var userName = String.format(USERNAME_FORMAT, name);
+
+        return new SecretBuilder()
+                .withNewMetadata()
+                .withName(secretName)
+                .withNamespace(schema.getMetadata().getNamespace())
+                .endMetadata()
+                .addToData(MYSQL_SECRET_USERNAME, encode(userName))
+                .addToData(MYSQL_SECRET_PASSWORD, encode(password))
+                .build();
+    }
+
+    private String getSecretName(String name) {
+        return String.format(SECRET_FORMAT, name);
+    }
+
+    @Override
+    public Result<Secret> match(Secret actual, MySQLSchema primary, Context context) {
+        final var desiredSecretName = getSecretName(primary.getMetadata().getName());
+        return Result.nonComputed(actual.getMetadata().getName().equals(desiredSecretName));
+    }
+
+    @Override
+    public ResourceID associatedSecondaryID(MySQLSchema primary) {
+        return new ResourceID(
+                String.format(SECRET_FORMAT, primary.getMetadata().getName()),
+                primary.getMetadata().getNamespace());
+    }
+}

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/SchemaService.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/SchemaService.java
@@ -30,7 +30,7 @@ public class SchemaService {
         }
     }
 
-    public void createSchemaAndRelatedUser(Connection connection, String schemaName,
+    public Schema createSchemaAndRelatedUser(Connection connection, String schemaName,
             String encoding,
             String userName,
             String password) {
@@ -50,6 +50,8 @@ public class SchemaService {
                 statement.execute(
                         format("GRANT ALL ON `%1$s`.* TO '%2$s'", schemaName, userName));
             }
+
+            return new Schema(schemaName, encoding);
         } catch (SQLException e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
This PR raise a bug in `ManagedDependentResourceContext::getDependentResource` because of
```java
var resourceList =
        dependentResources.stream()
            .filter(dr -> dr.getClass().equals(resourceClass))
            .collect(Collectors.toList());
```
`dr.getClass()` returns the proxy class when the dependent is a bean.