### PR TITLE
fix: allow to generate multiple operators from different reconcilers

### DIFF
--- a/.github/scripts/installOperatorUsingOlm.sh
+++ b/.github/scripts/installOperatorUsingOlm.sh
@@ -20,7 +20,7 @@ mvn clean package -Dquarkus.container-image.build=true \
   -Dquarkus.kubernetes.namespace=$K8S_NAMESPACE
 
 # Build Operator Bundle
-docker build -t $BUNDLE_IMAGE -f target/bundle/bundle.Dockerfile target/bundle
+docker build -t $BUNDLE_IMAGE -f target/bundle/$NAME-operator/bundle.Dockerfile target/bundle/$NAME-operator
 docker push $BUNDLE_IMAGE
 
 # Build Catalog image

--- a/.github/scripts/testPingPongSample.sh
+++ b/.github/scripts/testPingPongSample.sh
@@ -1,8 +1,10 @@
+NAMESPACE="${1}"
+
 # Test operator by creating a Joke Request resource
 kubectl apply -f samples/pingpong/src/main/k8s/pingrequest.yml
 
 # The ping reconciler should mark the ping resource as processed
-.github/scripts/waitFor.sh ping operators PROCESSED "my-ping-request -o jsonpath='{.status.state}'"
+.github/scripts/waitFor.sh ping $NAMESPACE PROCESSED "my-ping-request -o jsonpath='{.status.state}'"
 
 # And the pong reconciler should mark the new pong resource as processed
-.github/scripts/waitFor.sh pong operators PROCESSED "my-ping-request-pong -o jsonpath='{.status.state}'"
+.github/scripts/waitFor.sh pong $NAMESPACE PROCESSED "my-ping-request-pong -o jsonpath='{.status.state}'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,8 +113,8 @@ jobs:
         run: |
           SCRIPTS=$(pwd)/.github/scripts
 
-          # Install Joke operator
+          # Install Ping Pong operator
           $SCRIPTS/installOperatorUsingOlm.sh pingpong $(pwd)/samples/pingpong $KIND_REGISTRY
 
           # test joke sample
-          $SCRIPTS/testPingPongSample.sh
+          $SCRIPTS/testPingPongSample.sh operators

--- a/bundle-generator/deployment/pom.xml
+++ b/bundle-generator/deployment/pom.xml
@@ -32,6 +32,11 @@
             <groupId>io.fabric8</groupId>
             <artifactId>openshift-model-operatorhub</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
@@ -52,8 +52,6 @@ public class CsvManifestsBuilder extends ManifestsBuilder {
 
     public CsvManifestsBuilder(CSVMetadataHolder metadata, List<AugmentedResourceInfo> controllers) {
         super(metadata);
-        // record group to CRI mapping
-        // groupToCRInfo.computeIfAbsent(metadata.getGroup(), s -> new HashSet<>()).add(cri);
         csvBuilder = new ClusterServiceVersionBuilder()
                 .withNewMetadata().withName(getName()).endMetadata();
         final var csvSpecBuilder = csvBuilder

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CustomResourceManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CustomResourceManifestsBuilder.java
@@ -1,0 +1,47 @@
+package io.quarkiverse.operatorsdk.bundle.deployment.builders;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBinding;
+import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadataHolder;
+import io.quarkiverse.operatorsdk.runtime.CRDInfo;
+
+public class CustomResourceManifestsBuilder extends ManifestsBuilder {
+
+    private static final String MANIFESTS = "manifests";
+
+    private final CRDInfo crd;
+
+    public CustomResourceManifestsBuilder(CSVMetadataHolder metadata, CRDInfo crd) {
+        super(metadata);
+
+        this.crd = crd;
+    }
+
+    @Override
+    public Path getFileName() {
+        return Path.of(MANIFESTS, crd.getCrdName());
+    }
+
+    @Override
+    public byte[] getManifestData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,
+            List<ClusterRole> clusterRoles, List<RoleBinding> roleBindings, List<Role> roles, List<Deployment> deployments)
+            throws IOException {
+        return FileUtils.readFileToByteArray(new File(crd.getFilePath()));
+    }
+
+    @Override
+    public String getManifestType() {
+        return "Custom Resource Definition";
+    }
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/DefaultBundleWhenNoCsvMetadataTest.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/DefaultBundleWhenNoCsvMetadataTest.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.operatorsdk.bundle;
+
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.operatorsdk.bundle.sources.First;
+import io.quarkiverse.operatorsdk.bundle.sources.ReconcilerWithNoCsvMetadata;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class DefaultBundleWhenNoCsvMetadataTest {
+
+    private static final String BUNDLE = "bundle";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setApplicationName("reconciler-with-no-csv-metadata")
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(First.class, ReconcilerWithNoCsvMetadata.class));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void shouldWriteBundleEvenWhenCsvMetadataIsNotUsed() {
+        Assertions.assertTrue(
+                Files.exists(prodModeTestResults.getBuildDir().resolve(BUNDLE).resolve("reconciler-with-no-csv-metadata")));
+    }
+
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
@@ -1,0 +1,36 @@
+package io.quarkiverse.operatorsdk.bundle;
+
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.operatorsdk.bundle.sources.First;
+import io.quarkiverse.operatorsdk.bundle.sources.FirstReconciler;
+import io.quarkiverse.operatorsdk.bundle.sources.Second;
+import io.quarkiverse.operatorsdk.bundle.sources.SecondReconciler;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class MultipleOperatorsBundleTest {
+
+    private static final String BUNDLE = "bundle";
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(First.class, FirstReconciler.class,
+                            Second.class, SecondReconciler.class));
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void shouldWriteBundleForTheTwoOperators() {
+        Assertions.assertTrue(Files.exists(prodModeTestResults.getBuildDir().resolve(BUNDLE).resolve("first-operator")));
+        Assertions.assertTrue(Files.exists(prodModeTestResults.getBuildDir().resolve(BUNDLE).resolve("second-operator")));
+    }
+
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/First.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/First.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("samples.javaoperatorsdk.io")
+@Version("v1alpha1")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class First extends CustomResource<Void, Void> implements Namespaced {
+
+    public First() {
+    }
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/FirstReconciler.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/FirstReconciler.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadata;
+
+@CSVMetadata(name = "first-operator")
+public class FirstReconciler implements Reconciler<First> {
+
+    @Override
+    public UpdateControl<First> reconcile(First request, Context<First> context) {
+        return UpdateControl.noUpdate();
+    }
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/ReconcilerWithNoCsvMetadata.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/ReconcilerWithNoCsvMetadata.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+public class ReconcilerWithNoCsvMetadata implements Reconciler<First> {
+
+    @Override
+    public UpdateControl<First> reconcile(First request, Context<First> context) {
+        return UpdateControl.noUpdate();
+    }
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/Second.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/Second.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("samples.javaoperatorsdk.io")
+@Version("v1alpha1")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class Second extends CustomResource<Void, Void> implements Namespaced {
+
+    public Second() {
+    }
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/SecondReconciler.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/SecondReconciler.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadata;
+
+@CSVMetadata(name = "second-operator")
+public class SecondReconciler implements Reconciler<Second> {
+
+    @Override
+    public UpdateControl<Second> reconcile(Second request, Context<Second> context) {
+        return UpdateControl.noUpdate();
+    }
+}

--- a/samples/joke/README.md
+++ b/samples/joke/README.md
@@ -52,7 +52,7 @@ Make sure you have installed the [opm](https://github.com/operator-framework/ope
 2. Generate the Operator image and bundle manifests
 
 This example uses the [Quarkus Jib container image](https://quarkus.io/guides/container-image#jib) extension to build the Operator image. 
-Also, the Quarkus Operator SDK provides the `quarkus-operator-sdk-bundle-generator` extension that generates the Operator bundle manifests at `target/bundle`.
+Also, the Quarkus Operator SDK provides the `quarkus-operator-sdk-bundle-generator` extension that generates the Operator bundle manifests at `target/bundle/<operator name>`.
 So, you simply need to run the next Maven command to build and push the operator image, and also to generate the bundle manifests:
 
 ```shell
@@ -80,11 +80,11 @@ If you're using an insecure container registry, you'd also need to append the ne
 2. Build the Operator Bundle image
 
 An Operator Bundle is a container image that stores Kubernetes manifests and metadata associated with an operator. You can find more information about this in [here](https://olm.operatorframework.io/docs/tasks/creating-operator-bundle/). 
-In the previous step, we generated the bundle manifests at `target/bundle` which includes a ready-to-use Dockerfile at `target/bundle/bundle.Dockerfile` file that you will use to build and push the final Operator Bundle image to your container registry:
+In the previous step, we generated the bundle manifests at `target/bundle/<operator name from the CSV Metadata>` which includes a ready-to-use Dockerfile with name `bundle.Dockerfile` file that you will use to build and push the final Operator Bundle image to your container registry:
 
 ```shell
 JOKE_BUNDLE_IMAGE=<your container registry>/<your container registry namespace>/<bundle image name>:<tag>
-docker build -t $JOKE_BUNDLE_IMAGE -f target/bundle/bundle.Dockerfile target/bundle
+docker build -t $JOKE_BUNDLE_IMAGE -f target/bundle/<operator name>/bundle.Dockerfile target/bundle/<operator name>
 docker push $JOKE_BUNDLE_IMAGE
 ```
 


### PR DESCRIPTION
Added unit test to verify this scenario.
Manually tested using the ping pong sample and annotating the two reconcilers with `@CSVMetadata(name = "ping-operator")` and the same with the pong reconciler.