### PR TITLE
feat!: explicit interaction between CRD generate/apply and launch mode

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationTest.java
@@ -1,0 +1,82 @@
+package io.quarkiverse.operatorsdk.deployment;
+
+import static io.quarkiverse.operatorsdk.deployment.CRDGeneration.shouldApply;
+import static io.quarkiverse.operatorsdk.deployment.CRDGeneration.shouldGenerate;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import io.quarkus.runtime.LaunchMode;
+
+class CRDGenerationTest {
+
+    public static Stream<Arguments> shouldGenerateShouldWork() {
+        return Stream.of(
+                // default cases
+                Arguments.of(Optional.empty(), Optional.empty(), LaunchMode.NORMAL, true),
+                Arguments.of(Optional.empty(), Optional.empty(), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.empty(), Optional.empty(), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(false), Optional.empty(), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(false), Optional.empty(), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.of(false), Optional.empty(), LaunchMode.NORMAL, false),
+                Arguments.of(Optional.of(true), Optional.empty(), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(true), Optional.empty(), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.of(true), Optional.empty(), LaunchMode.NORMAL, true),
+                Arguments.of(Optional.empty(), Optional.of(true), LaunchMode.NORMAL, true),
+                Arguments.of(Optional.empty(), Optional.of(true), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.empty(), Optional.of(true), LaunchMode.TEST, true),
+                // explicit apply should override generate, except in normal mode
+                Arguments.of(Optional.of(false), Optional.of(true), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(false), Optional.of(true), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.of(false), Optional.of(true), LaunchMode.NORMAL, false),
+                Arguments.of(Optional.of(true), Optional.of(true), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(true), Optional.of(true), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.of(true), Optional.of(true), LaunchMode.NORMAL, true),
+                // dev or test mode should generate by default unless explicitly forbidden
+                Arguments.of(Optional.empty(), Optional.of(false), LaunchMode.NORMAL, true),
+                Arguments.of(Optional.empty(), Optional.of(false), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.empty(), Optional.of(false), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(false), Optional.of(false), LaunchMode.TEST, false),
+                Arguments.of(Optional.of(false), Optional.of(false), LaunchMode.DEVELOPMENT, false),
+                Arguments.of(Optional.of(false), Optional.of(false), LaunchMode.NORMAL, false),
+                Arguments.of(Optional.of(true), Optional.of(false), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(true), Optional.of(false), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.of(true), Optional.of(false), LaunchMode.NORMAL, true));
+    }
+
+    public static Stream<Arguments> shouldApplyShouldWork() {
+        return Stream.of(
+                // default cases
+                Arguments.of(Optional.empty(), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.empty(), LaunchMode.TEST, true),
+
+                // should never apply in normal mode regardless of explicit value
+                Arguments.of(Optional.empty(), LaunchMode.NORMAL, false),
+                Arguments.of(Optional.of(true), LaunchMode.NORMAL, false),
+                Arguments.of(Optional.of(false), LaunchMode.NORMAL, false),
+
+                // explicit value should be in effect
+                Arguments.of(Optional.of(true), LaunchMode.DEVELOPMENT, true),
+                Arguments.of(Optional.of(true), LaunchMode.TEST, true),
+                Arguments.of(Optional.of(false), LaunchMode.DEVELOPMENT, false),
+                Arguments.of(Optional.of(false), LaunchMode.TEST, false));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldGenerateShouldWork(Optional<Boolean> configuredGenerate, Optional<Boolean> configuredApply, LaunchMode mode,
+            boolean expected) {
+        assertEquals(expected, shouldGenerate(configuredGenerate, configuredApply, mode));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void shouldApplyShouldWork(Optional<Boolean> configuredApply, LaunchMode mode, boolean expected) {
+        assertEquals(expected, shouldApply(configuredApply, mode));
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDConfiguration.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.operatorsdk.runtime;
 
 import java.util.List;
+import java.util.Optional;
 
 import io.fabric8.kubernetes.client.CustomResource;
 import io.quarkus.runtime.annotations.ConfigGroup;
@@ -11,8 +12,6 @@ public class CRDConfiguration {
 
     public static final String DEFAULT_OUTPUT_DIRECTORY = "kubernetes";
     public static final String DEFAULT_VALIDATE = "true";
-    public static final String DEFAULT_GENERATE = "true";
-    public static final String DEFAULT_APPLY = "false";
     public static final String DEFAULT_VERSIONS = "v1";
     /**
      * Whether the operator should check that the CRD is properly deployed and that the associated
@@ -26,15 +25,15 @@ public class CRDConfiguration {
      * Whether the extension should automatically generate the CRD based on {@link CustomResource}
      * implementations.
      */
-    @ConfigItem(defaultValue = DEFAULT_GENERATE)
-    public Boolean generate;
+    @ConfigItem
+    public Optional<Boolean> generate;
 
     /**
      * Whether the extension should automatically apply updated CRDs when they change.
      * When running on DEV mode, the CRD changes will always be applied automatically.
      */
-    @ConfigItem(defaultValue = DEFAULT_APPLY)
-    public Boolean apply;
+    @ConfigItem
+    public Optional<Boolean> apply;
 
     /**
      * Comma-separated list of which CRD versions should be generated.

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDGenerationInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDGenerationInfo.java
@@ -32,6 +32,7 @@ public class CRDGenerationInfo {
         return generated;
     }
 
+    // Needed by Quarkus: if this method isn't present, state is not properly set
     public boolean isApplyCRDs() {
         return applyCRDs;
     }

--- a/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.DisabledOnNativeImage;
 import io.quarkus.test.junit.QuarkusTest;
 
 @QuarkusTest
@@ -27,6 +28,7 @@ class OperatorSDKResourceTest {
     }
 
     @Test
+    @DisabledOnNativeImage("Skipped because native tests are run using LaunchMode.NORMAL")
     void shouldApplyCRDsByDefaultInTestMode() {
         given().when().get("/operator/config").then().statusCode(200).body(
                 "applyCRDs", equalTo(true));

--- a/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
@@ -27,9 +27,9 @@ class OperatorSDKResourceTest {
     }
 
     @Test
-    void shouldNotApplyCRDsByDefault() {
+    void shouldApplyCRDsByDefaultInTestMode() {
         given().when().get("/operator/config").then().statusCode(200).body(
-                "applyCRDs", equalTo(false));
+                "applyCRDs", equalTo(true));
     }
 
     @Test


### PR DESCRIPTION
It is now impossible to automatically apply the CRD to the cluster in
normal mode, even if explicitly asked for, to prevent potential issues
in production. CRD is automatically applies in dev or test mode now,
though, which is different from the previous behavior, where you needed
to activate the feature explicitly.

Fixes #297
