### PR TITLE
release 3.0.8

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Java Operator SDK Extension
 release:
-  current-version: 3.0.7
-  next-version: 3.0.8-SNAPSHOT
+  current-version: 3.0.8
+  next-version: 3.0.9-SNAPSHOT
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -38,11 +38,6 @@
     <url>https://github.com/quarkiverse/quarkus-operator-sdk/issues/</url>
   </issueManagement>
 
-  <properties>
-    <quarkus.version>2.7.5.Final</quarkus.version>
-    <java-operator-sdk.version>2.1.4</java-operator-sdk.version>
-    <kubernetes-client.version>5.12.2</kubernetes-client.version>
-  </properties>
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -7,7 +7,6 @@
     <version>3.0.8-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-  <version>3.0.8-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Quarkus - Operator SDK - Build Parent</name>
   <properties>
@@ -17,7 +16,6 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>2.7.5.Final</quarkus.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>
@@ -31,6 +29,29 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkiverse.operatorsdk</groupId>
+      <artifactId>quarkus-operator-sdk-bom</artifactId>
+      <version>${project.version}</version>
+      <type>pom</type>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+
   <repositories>
     <repository>
       <id>oss-sonatype</id>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
@@ -9,7 +11,11 @@
   </parent>
   <artifactId>quarkus-operator-sdk-integration-tests</artifactId>
   <name>Quarkus - Operator SDK - Integration Tests</name>
-   <dependencies>
+  <properties>
+    <maven.deploy.skip>true</maven.deploy.skip>
+    <gpg.skip>true</gpg.skip>
+  </properties>
+  <dependencies>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
@@ -36,16 +42,21 @@
        <groupId>io.quarkus</groupId>
        <artifactId>quarkus-resteasy-jackson</artifactId>
      </dependency>
-     <dependency>
-       <groupId>io.rest-assured</groupId>
-       <artifactId>rest-assured</artifactId>
-       <scope>test</scope>
-     </dependency>
-     <dependency>
-       <groupId>io.fabric8</groupId>
-       <artifactId>istio-model-v1beta1</artifactId>
-     </dependency>
-   </dependencies>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>istio-model-v1beta1</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
   <build>
     <plugins>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,11 @@
   <version>3.0.8-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Quarkus - Operator SDK - Parent</name>
+  <properties>
+    <quarkus.version>2.7.6.Final</quarkus.version>
+    <java-operator-sdk.version>2.1.4</java-operator-sdk.version>
+    <kubernetes-client.version>5.12.2</kubernetes-client.version>
+  </properties>
 
   <profiles>
     <profile>

--- a/samples/joke/pom.xml
+++ b/samples/joke/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>

--- a/samples/mysql-schema/pom.xml
+++ b/samples/mysql-schema/pom.xml
@@ -67,6 +67,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
- feat: also release snapshots for 3.0.x branch
- chore: update to JOSDK 2.1.4-SNAPSHOT
- feat: use mariadb as drop-in mysql replacement
- fix: remove version override
- chore: update to Fabric8 client 5.12.2
- chore: update to JOSDK 2.1.4
- fix: also add finalizers to target resources in roles when needed
- chore: release 3.0.7
- fix: shouldn't start operator when testing
- fix: disable delayed registration test
- fix: always add finalizers sub-resource since it's widely used
- [maven-release-plugin] prepare release 3.0.7
- [maven-release-plugin] prepare for next development iteration
- chore: improve build and upgrade to Quarkus 2.7.6
- chore: prepare for 3.0.8 release
