### PR TITLE
fix: keep the project compatible with Quarkus 2.7

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/QuarkusControllerConfigurationBuilder.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/QuarkusControllerConfigurationBuilder.java
@@ -284,7 +284,8 @@ class QuarkusControllerConfigurationBuilder {
             AnnotationConfigurableAugmentedClassInfo configurableInfo) {
         if (configurableInfo != null) {
             final var associatedConfigurationClass = configurableInfo.getAssociatedConfigurationClass();
-            if (reconcilerInfo.classInfo().annotationsMap().containsKey(associatedConfigurationClass)) {
+            // Keeping the deprecated method due to compatibility with Quarkus 2.7.
+            if (reconcilerInfo.classInfo().annotations().containsKey(associatedConfigurationClass)) {
                 return ClassLoadingUtils
                         .loadClass(associatedConfigurationClass.toString(), Object.class);
             }


### PR DESCRIPTION
@metacosm Quarkus 2.7, which is the latest productized version, brings an older version of Jandex. This PR makes the project compatible with Quarkus 2.7 at the expense of using a deprecated method (until a new productized version of Quarkus is released).

Maybe setting up a CI that overrides the Quarkus version and checks the compatibility would prevent similar issues in the future?