### PR TITLE
feat: allow customization of Fabric8's ObjectMapper

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -33,6 +33,7 @@ import io.quarkiverse.operatorsdk.runtime.CRDConfiguration;
 import io.quarkiverse.operatorsdk.runtime.CRDGenerationInfo;
 import io.quarkiverse.operatorsdk.runtime.CRDInfo;
 import io.quarkiverse.operatorsdk.runtime.ConfigurationServiceRecorder;
+import io.quarkiverse.operatorsdk.runtime.KubernetesClientSerializationCustomizer;
 import io.quarkiverse.operatorsdk.runtime.NoOpMetricsProvider;
 import io.quarkiverse.operatorsdk.runtime.OperatorProducer;
 import io.quarkiverse.operatorsdk.runtime.QuarkusConfigurationService;
@@ -85,6 +86,10 @@ class OperatorSDKProcessor {
                 new IndexDependencyBuildItem("io.javaoperatorsdk", "operator-framework-core"));
         // mark ObjectMapper as non-removable
         unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(ObjectMapper.class));
+
+        // register CDI qualifier for customization of the fabric8 ObjectMapper
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(
+                KubernetesClientSerializationCustomizer.class));
 
         // only add micrometer support if the capability is supported
         if (metricsCapability.map(m -> m.metricsSupported(MetricsFactory.MICROMETER)).orElse(false)) {

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
@@ -11,7 +11,6 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.quarkus.arc.Arc;
-import io.quarkus.arc.InstanceHandle;
 import io.quarkus.jackson.ObjectMapperCustomizer;
 import io.quarkus.runtime.LaunchMode;
 import io.quarkus.runtime.annotations.Recorder;
@@ -47,9 +46,8 @@ public class ConfigurationServiceRecorder {
             // customize fabric8 mapper
             final var mapper = Serialization.jsonMapper();
             mapper.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-            Arc.container().listAll(ObjectMapperCustomizer.class, KubernetesClientSerializationCustomizer.Literal.INSTANCE)
+            Arc.container().select(ObjectMapperCustomizer.class, KubernetesClientSerializationCustomizer.Literal.INSTANCE)
                     .stream()
-                    .map(InstanceHandle::get)
                     .sorted()
                     .forEach(c -> c.customize(mapper));
 

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/KubernetesClientSerializationCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/KubernetesClientSerializationCustomizer.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.operatorsdk.runtime;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Qualifier;
+
+@Qualifier
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KubernetesClientSerializationCustomizer {
+
+    final class Literal extends AnnotationLiteral<KubernetesClientSerializationCustomizer>
+            implements KubernetesClientSerializationCustomizer {
+
+        public static final Literal INSTANCE = new Literal();
+        private static final long serialVersionUID = 1L;
+
+        private Literal() {
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusConfigurationService.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.Config;
@@ -45,20 +45,19 @@ public class QuarkusConfigurationService extends AbstractConfigurationService {
             Collection<QuarkusControllerConfiguration> configurations,
             KubernetesClient client,
             CRDGenerationInfo crdInfo, int maxThreads,
-            int timeout, Metrics metrics, boolean startOperator) {
+            int timeout, Metrics metrics, boolean startOperator, ObjectMapper mapper) {
         super(version);
-        final var fMapper = getObjectMapper().configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
         final var cloner = new Cloner() {
             @Override
             public <R extends HasMetadata> R clone(R r) {
                 try {
-                    return (R) fMapper.readValue(fMapper.writeValueAsString(r), r.getClass());
+                    return (R) mapper.readValue(mapper.writeValueAsString(r), r.getClass());
                 } catch (JsonProcessingException e) {
                     throw new IllegalStateException(e);
                 }
             }
         };
-        init(cloner, fMapper);
+        init(cloner, mapper);
         this.startOperator = startOperator;
         this.client = client;
         this.metrics = metrics;

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -22,6 +22,7 @@ This extension integrates the https://javaoperatorsdk.io[Java Operator SDK] proj
 - Automatically adds a SmallRye health check
 - Can easily generate a Docker image via JIB
 - Sets up reflection for native binary generation
+- Customize the JSON serialization that the Fabric8 client relies on by providing an `ObjectMapperCustomizer` implementation, qualified with the `@KubernetesClientSerializationCustomizer` annotation
 
 == Installation
 

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/EmptyCR.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/EmptyCR.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.operatorsdk.it;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.quarkiverse.operatorsdk.it.EmptyCR.EmptySpec;
+
+@Group("josdk.quarkiverse.io")
+@Version("v1alpha1")
+public class EmptyCR extends CustomResource<EmptySpec, Void> {
+
+    static class EmptySpec {
+
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/EmptyReconciler.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/EmptyReconciler.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.operatorsdk.it;
+
+import static io.quarkiverse.operatorsdk.it.EmptyReconciler.NAME;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+@ControllerConfiguration(name = NAME)
+public class EmptyReconciler implements Reconciler<EmptyCR> {
+
+    public static final String NAME = "empty";
+
+    @Override
+    public UpdateControl<EmptyCR> reconcile(EmptyCR emptyCR, Context<EmptyCR> context)
+            throws Exception {
+        return UpdateControl.noUpdate();
+    }
+}

--- a/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
@@ -76,7 +76,7 @@ class OperatorSDKResourceTest {
                 TestReconciler.NAME,
                 SecretReconciler.class.getSimpleName().toLowerCase(Locale.ROOT),
                 GatewayReconciler.class.getSimpleName().toLowerCase(Locale.ROOT),
-                DependentDefiningReconciler.NAME, NamespaceFromEnvReconciler.NAME));
+                DependentDefiningReconciler.NAME, NamespaceFromEnvReconciler.NAME, EmptyReconciler.NAME));
     }
 
     @Test


### PR DESCRIPTION
- feat: make it possible to customize Fabric8's mapper
- fix: register CDI qualifier so that beans can properly be found
- docs: add bit about fabric8's serialization customization
