### PR TITLE
fix: remove fabric8 k8s client version override

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,13 +40,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.fabric8</groupId>
-          <artifactId>kubernetes-client-bom</artifactId>
-          <version>${kubernetes-client.version}</version>
-          <type>pom</type>
-          <scope>import</scope>
-        </dependency>
         <dependency>
           <groupId>io.quarkus</groupId>
           <artifactId>quarkus-bom</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <quarkus.version>2.13.0.Final</quarkus.version>
     <java-operator-sdk.version>3.2.1</java-operator-sdk.version>
-    <kubernetes-client.version>5.12.3</kubernetes-client.version>
   </properties>
 
   <profiles>


### PR DESCRIPTION
Removes the version override for `io.fabric8:kubernetes-*`. Versions of these dependencies are already contained in the `quarkus-bom`.

@metacosm This removes the version override we discussed.