### PR TITLE
Sync clusterserviceversion filename and extension

### DIFF
--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
@@ -155,7 +155,7 @@ public class CsvManifestsBuilder extends ManifestsBuilder {
     }
 
     public Path getFileName() {
-        return Path.of(MANIFESTS, getName() + ".csv.yml");
+        return Path.of(MANIFESTS, getName() + ".clusterserviceversion.yaml");
     }
 
     public byte[] getManifestData(List<ServiceAccount> serviceAccounts, List<ClusterRoleBinding> clusterRoleBindings,

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
@@ -53,7 +53,7 @@ public class MultipleOperatorsBundleTest {
         checkBundleFor(bundle, "third-operator", Third.class);
         final var thirdManifests = bundle.resolve("third-operator").resolve("manifests");
         assertFileExistsIn(thirdManifests.resolve(getCRDNameFor(External.class)), thirdManifests);
-        final var csvAsString = Files.readString(thirdManifests.resolve("third-operator.csv.yml"));
+        final var csvAsString = Files.readString(thirdManifests.resolve("third-operator.clusterserviceversion.yaml"));
         final var csv = Serialization.unmarshal(csvAsString, ClusterServiceVersion.class);
         assertEquals(HasMetadata.getFullResourceName(Third.class),
                 csv.getSpec().getCustomresourcedefinitions().getOwned().get(0).getName());
@@ -72,7 +72,7 @@ public class MultipleOperatorsBundleTest {
         assertFileExistsIn(operatorManifests.resolve("bundle.Dockerfile"), bundle);
         final var manifests = operatorManifests.resolve("manifests");
         assertFileExistsIn(manifests, bundle);
-        assertFileExistsIn(manifests.resolve(operatorName + ".csv.yml"), manifests);
+        assertFileExistsIn(manifests.resolve(operatorName + ".clusterserviceversion.yaml"), manifests);
         assertFileExistsIn(manifests.resolve(getCRDNameFor(resourceClass)), manifests);
         final var metadata = operatorManifests.resolve("metadata");
         assertFileExistsIn(metadata, bundle);


### PR DESCRIPTION
All operators in Kubernetes and Openshift Community Operators repositories uses `.clusterserviceversion.yaml` for filename. 
I would like to propose to sync ClusterServiceVersion filename generated by quarkus-operator-sdk with operators repository.