### PR TITLE
fix: use deployment namespace if provided when generating RoleBindings

### DIFF
--- a/samples/exposedapp/src/main/resources/application.properties
+++ b/samples/exposedapp/src/main/resources/application.properties
@@ -3,6 +3,3 @@
 #quarkus.container-image.name=expose-operator
 # set to true to automatically apply CRDs to the cluster when they get regenerated
 quarkus.operator-sdk.crd.apply=true
-# test values to check RBACs
-%test.quarkus.kubernetes.namespace=opns
-%test.quarkus.operator-sdk.controllers.exposedapp.namespaces=crns

--- a/samples/exposedapp/src/test/java/io/halkyon/ExposedAppReconcilerTest.java
+++ b/samples/exposedapp/src/test/java/io/halkyon/ExposedAppReconcilerTest.java
@@ -29,12 +29,9 @@ class ExposedAppReconcilerTest {
         operator.start();
 
         final var app = new ExposedApp();
-
-        // use namespace name defined in application.properties for test profile
-        final String namespace = "crns";
         final var metadata = new ObjectMetaBuilder()
                 .withName("test-app")
-                .withNamespace(namespace)
+                .withNamespace(client.getNamespace())
                 .build();
         app.setMetadata(metadata);
         app.getSpec().setImageRef("group/imageName:tag");


### PR DESCRIPTION
- fix: use deployment namespace if provided when generating RoleBindings
- fix: make sure we run after the AddNamespaceDecorator
- chore: test that different deployed in / watched namespaces works
