### PR TITLE
Implement a compile time check of the Quarkus version

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -76,6 +76,19 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>templating-maven-plugin</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <id>filtering-java-templates</id>
+            <goals>
+              <goal>filter-sources</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/deployment/src/main/java-templates/io/quarkiverse/operatorsdk/deployment/Versions.java
+++ b/core/deployment/src/main/java-templates/io/quarkiverse/operatorsdk/deployment/Versions.java
@@ -1,0 +1,7 @@
+package io.quarkiverse.operatorsdk.deployment;
+
+public final class Versions {
+
+  public static final String QUARKUS = "${quarkus.version}";
+
+}

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -138,8 +138,13 @@ class OperatorSDKProcessor {
 
         String runtimeQuarkusVersion = Quarkus.class.getPackage().getImplementationVersion();
         if (!runtimeQuarkusVersion.equals(Versions.QUARKUS)) {
-            throw new RuntimeException("Incompatible Quarkus version, found: \"" + runtimeQuarkusVersion + "\", expected: \""
-                    + Versions.QUARKUS + "\"");
+            String message = "Incompatible Quarkus version found: \"" + runtimeQuarkusVersion + "\", expected: \""
+                    + Versions.QUARKUS + "\"";
+            if (buildTimeConfiguration.failOnVersionCheck) {
+                throw new RuntimeException(message);
+            } else {
+                log.warn(message);
+            }
         }
 
         final CRDConfiguration crdConfig = buildTimeConfiguration.crd;

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
 
@@ -63,6 +62,7 @@ import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.kubernetes.client.spi.KubernetesClientBuildItem;
 import io.quarkus.kubernetes.spi.DecoratorBuildItem;
+import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.metrics.MetricsFactory;
 
@@ -135,8 +135,8 @@ class OperatorSDKProcessor {
             BuildProducer<ForceNonWeakReflectiveClassBuildItem> forcedReflectionClasses,
             BuildProducer<GeneratedCRDInfoBuildItem> generatedCRDInfo,
             LiveReloadBuildItem liveReload, LaunchModeBuildItem launchMode) {
-        
-        String runtimeQuarkusVersion = ConfigProvider.getConfig().getValue("quarkus.platform.version", String.class);
+
+        String runtimeQuarkusVersion = Quarkus.class.getPackage().getImplementationVersion();
         if (!runtimeQuarkusVersion.equals(Versions.QUARKUS)) {
             throw new RuntimeException("Incompatible Quarkus version, found: \"" + runtimeQuarkusVersion + "\", expected: \""
                     + Versions.QUARKUS + "\"");

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 
 import javax.inject.Singleton;
 
+import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
 
@@ -134,6 +135,12 @@ class OperatorSDKProcessor {
             BuildProducer<ForceNonWeakReflectiveClassBuildItem> forcedReflectionClasses,
             BuildProducer<GeneratedCRDInfoBuildItem> generatedCRDInfo,
             LiveReloadBuildItem liveReload, LaunchModeBuildItem launchMode) {
+        
+        String runtimeQuarkusVersion = ConfigProvider.getConfig().getValue("quarkus.platform.version", String.class);
+        if (!runtimeQuarkusVersion.equals(Versions.QUARKUS)) {
+            throw new RuntimeException("Incompatible Quarkus version, found: \"" + runtimeQuarkusVersion + "\", expected: \""
+                    + Versions.QUARKUS + "\"");
+        }
 
         final CRDConfiguration crdConfig = buildTimeConfiguration.crd;
         final boolean validateCustomResources = ConfigurationUtils.shouldValidateCustomResources(

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -151,10 +151,11 @@ class OperatorSDKProcessor {
         String runtimeQuarkusVersion = Quarkus.class.getPackage().getImplementationVersion();
         checkVersionCompatibility(runtimeQuarkusVersion, Versions.QUARKUS, "Quarkus");
 
-//        String runtimeFabric8Version = io.fabric8.kubernetes.client.Version.clientVersion();
-//        String josdkFabric8Version = io.javaoperatorsdk.operator.Versions.KUBERNETES_CLIENT;
-//        String quarkusFabric8Version = io.quarkus.kubernetes.client.deployment.Versions.KUBERNETES_CLIENT;
-//        checkVersionCompatibility(runtimeFabric8Version, quarkusFabric8Version, "Fabric8 kubernetes-client");
+        //        String runtimeFabric8Version = io.fabric8.kubernetes.client.Version.clientVersion();
+        //        String josdkFabric8Version = io.javaoperatorsdk.operator.Versions.KUBERNETES_CLIENT;
+        //        String quarkusFabric8Version = io.quarkus.kubernetes.client.deployment.Versions.KUBERNETES_CLIENT;
+        //        checkVersionCompatibility(josdkFabric8Version, quarkusFabric8Version, "JOSDK Fabric8 kubernetes-client ");
+        //        checkVersionCompatibility(runtimeFabric8Version, quarkusFabric8Version, "Fabric8 kubernetes-client");
 
         final CRDConfiguration crdConfig = buildTimeConfiguration.crd;
         final boolean validateCustomResources = ConfigurationUtils.shouldValidateCustomResources(

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
@@ -56,4 +56,10 @@ public class BuildTimeOperatorConfiguration {
      */
     @ConfigItem(defaultValue = "true")
     public Boolean stopOnInformerErrorDuringStartup;
+
+    /**
+     * Whether to fail or only emit a warning on version validation at compile time.
+     */
+    @ConfigItem(defaultValue = "true")
+    public Boolean failOnVersionCheck;
 }


### PR DESCRIPTION
This is a naive implementation of a compile time check for the Quarkus version.

Unfortunately the version returned from `quarkus.platform.version` is `999-SNAPSHOT` and is not usable ...