### PR TITLE
Fix having duplicate permissions in generated CSV

### DIFF
--- a/samples/pingpong/src/test/java/io/quarkiverse/operatorsdk/samples/pingpong/AssertGeneratedResourcesIT.java
+++ b/samples/pingpong/src/test/java/io/quarkiverse/operatorsdk/samples/pingpong/AssertGeneratedResourcesIT.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.operatorsdk.samples.pingpong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.openshift.api.model.operatorhub.v1alpha1.ClusterServiceVersion;
+import io.fabric8.openshift.api.model.operatorhub.v1alpha1.StrategyDeploymentPermissions;
+
+class AssertGeneratedResourcesIT {
+
+    @Test
+    void verifyPingPongClusterServiceVersion() throws FileNotFoundException {
+        KubernetesList list = Serialization
+                .unmarshalAsList(new FileInputStream(
+                        "target/bundle/pingpong-operator/manifests/pingpong-operator.clusterserviceversion.yaml"));
+        assertNotNull(list);
+        ClusterServiceVersion csv = findFirst(list, ClusterServiceVersion.class).orElseThrow(IllegalStateException::new);
+        // should have only one cluster rule permission
+        List<StrategyDeploymentPermissions> clusterPermissions = csv.getSpec().getInstall().getSpec().getClusterPermissions();
+        assertEquals(1, clusterPermissions.size());
+        List<StrategyDeploymentPermissions> permissions = csv.getSpec().getInstall().getSpec().getPermissions();
+        assertEquals(1, permissions.size());
+    }
+
+    <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+        return (Optional<T>) list.getItems().stream()
+                .filter(i -> t.isInstance(i))
+                .findFirst();
+    }
+
+}


### PR DESCRIPTION
Before these changes, the permissions were duplicated for clusterPermissions and permissions in the CSV manifests:

```yaml
clusterPermissions:
      - rules:
        - apiGroups:
          - apiextensions.k8s.io
          resources:
          - customresourcedefinitions
          verbs:
          - get
          - list
        serviceAccountName: quarkus-operator-sdk-samples-pingpong
       - rules:
        - apiGroups:
          - apiextensions.k8s.io
          resources:
          - customresourcedefinitions
          verbs:
          - get
          - list
        serviceAccountName: quarkus-operator-sdk-samples-pingpong
```

And should have only one:

```yaml
clusterPermissions:
      - rules:
        - apiGroups:
          - apiextensions.k8s.io
          resources:
          - customresourcedefinitions
          verbs:
          - get
          - list
        serviceAccountName: quarkus-operator-sdk-samples-pingpong
```

Moreover, the new logic will aggregate the rules onto the permission with the same service account name.