### PR TITLE
chore: update to Quarkus 3.0.0, migrate to Jakarta EE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         #        quarkus-version: ${{ fromJSON(needs.get-quarkus-versions.outputs.matrix) }}
-        quarkus-version: [ 999-SNAPSHOT ]
+        quarkus-version: [ 3.0.0.Alpha4 ]
         java-version: [ 11, 17 ]
     uses: ./.github/workflows/build-for-quarkus-version.yml
     with:

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-parent</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk-bom</artifactId>
   <name>Quarkus - Operator SDK - BOM</name>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-parent</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk-build-parent</artifactId>
   <packaging>pom</packaging>

--- a/bundle-generator/deployment/pom.xml
+++ b/bundle-generator/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-bundle-generator-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Quarkus - Operator SDK - Bundle Generator - Deployment</name>

--- a/bundle-generator/pom.xml
+++ b/bundle-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/bundle-generator/runtime/pom.xml
+++ b/bundle-generator/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-bundle-generator-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
     </parent>
 
     <name>Quarkus - Operator SDK - Bundle Generator - Runtime</name>

--- a/common-deployment/pom.xml
+++ b/common-deployment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/Constants.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/Constants.java
@@ -23,6 +23,5 @@ public class Constants {
     public static final DotName DEPENDENT_RESOURCE = DotName.createSimple(DependentResource.class.getName());
     public static final DotName CONFIGURED = DotName.createSimple(Configured.class.getName());
     public static final DotName ANNOTATION_CONFIGURABLE = DotName.createSimple(AnnotationConfigurable.class.getName());
-
     public static final DotName OBJECT = DotName.createSimple(Object.class.getName());
 }

--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/SelectiveAugmentedClassInfo.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/SelectiveAugmentedClassInfo.java
@@ -62,7 +62,7 @@ public abstract class SelectiveAugmentedClassInfo {
     }
 
     private void initTypesIfNeeded(IndexView index) {
-        if (types == null && !OBJECT.equals(extendedOrImplementedClass)) {
+        if (expectedParameterTypesCardinality > 0 && types == null && !OBJECT.equals(extendedOrImplementedClass)) {
             final List<Type> typeParameters;
             try {
                 typeParameters = JandexUtil.resolveTypeParameters(classInfo.name(),

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-core-parent</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk-deployment</artifactId>
   <name>Quarkus - Operator SDK - Core - Deployment</name>

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -18,6 +18,8 @@ import org.jboss.logging.Logger;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.javaoperatorsdk.operator.api.config.ConfigurationService;
+import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
+import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.quarkiverse.operatorsdk.common.AnnotationConfigurableAugmentedClassInfo;
 import io.quarkiverse.operatorsdk.common.ClassUtils;
 import io.quarkiverse.operatorsdk.common.ConfigurationUtils;
@@ -70,6 +72,7 @@ class OperatorSDKProcessor {
     static final Logger log = Logger.getLogger(OperatorSDKProcessor.class.getName());
 
     private static final String FEATURE = "operator-sdk";
+    private static final String DEFAULT_METRIC_BINDER_CLASS_NAME = "io.quarkiverse.operatorsdk.runtime.MicrometerMetricsProvider";
 
     private BuildTimeOperatorConfiguration buildTimeConfiguration;
 
@@ -85,16 +88,19 @@ class OperatorSDKProcessor {
         // mark ObjectMapper as non-removable
         unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(ObjectMapper.class));
 
-        // register CDI qualifier for customization of the fabric8 ObjectMapper
-        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(
-                KubernetesClientSerializationCustomizer.class));
+        // mark Metrics implementations as non-removable
+        unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(Metrics.class));
 
-        // only add micrometer support if the capability is supported
+        // mark LeaderElectionConfiguration as non-removable
+        unremovableBeans.produce(UnremovableBeanBuildItem.beanTypes(LeaderElectionConfiguration.class));
+
+        // register CDI qualifier for customization of the fabric8 ObjectMapper
+        additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(KubernetesClientSerializationCustomizer.class));
+
+        // add default bean based on whether or not micrometer is enabled
         if (metricsCapability.map(m -> m.metricsSupported(MetricsFactory.MICROMETER)).orElse(false)) {
             // we use the class name to not import any micrometer-related dependencies to prevent activation
-            additionalBeans.produce(
-                    AdditionalBeanBuildItem.unremovableOf(
-                            "io.quarkiverse.operatorsdk.runtime.MicrometerMetricsProvider"));
+            additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(DEFAULT_METRIC_BINDER_CLASS_NAME));
         } else {
             additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(NoOpMetricsProvider.class));
         }

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -10,8 +10,6 @@ import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.inject.Singleton;
-
 import org.jboss.jandex.DotName;
 import org.jboss.logging.Logger;
 
@@ -65,6 +63,7 @@ import io.quarkus.kubernetes.spi.DecoratorBuildItem;
 import io.quarkus.runtime.Quarkus;
 import io.quarkus.runtime.QuarkusApplication;
 import io.quarkus.runtime.metrics.MetricsFactory;
+import jakarta.inject.Singleton;
 
 @SuppressWarnings({ "unused" })
 class OperatorSDKProcessor {

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>5.1.0-SNAPSHOT</version>
+        <version>6.0.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-core-parent</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk</artifactId>
   <name>Quarkus - Operator SDK - Core - Runtime</name>

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/AppEventListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/AppEventListener.java
@@ -1,15 +1,14 @@
 package io.quarkiverse.operatorsdk.runtime;
 
-import javax.annotation.Priority;
-import javax.enterprise.event.Observes;
-import javax.interceptor.Interceptor;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import io.javaoperatorsdk.operator.Operator;
 import io.quarkus.runtime.ShutdownEvent;
 import io.quarkus.runtime.StartupEvent;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.event.Observes;
+import jakarta.interceptor.Interceptor;
 
 public class AppEventListener {
     private static final Logger log = LoggerFactory.getLogger(AppEventListener.class);

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.operatorsdk.runtime;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -62,4 +63,11 @@ public class BuildTimeOperatorConfiguration {
      */
     @ConfigItem(defaultValue = "true")
     public Boolean failOnVersionCheck;
+
+    /**
+     * The list of profile names for which leader election should be activated. This is mostly useful for testing scenarios
+     * where leader election behavior might lead to issues.
+     */
+    @ConfigItem(defaultValue = "prod")
+    public List<String> activateLeaderElectionForProfiles;
 }

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/KubernetesClientSerializationCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/KubernetesClientSerializationCustomizer.java
@@ -6,8 +6,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import javax.enterprise.util.AnnotationLiteral;
-import javax.inject.Qualifier;
+import jakarta.enterprise.util.AnnotationLiteral;
+import jakarta.inject.Qualifier;
 
 @Qualifier
 @Documented

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/MicrometerMetricsProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/MicrometerMetricsProvider.java
@@ -1,13 +1,12 @@
 package io.quarkiverse.operatorsdk.runtime;
 
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.quarkus.arc.DefaultBean;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class MicrometerMetricsProvider implements MeterBinder {

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/MicrometerMetricsProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/MicrometerMetricsProvider.java
@@ -7,6 +7,7 @@ import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.javaoperatorsdk.operator.monitoring.micrometer.MicrometerMetrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.quarkus.arc.DefaultBean;
 
 @Singleton
 public class MicrometerMetricsProvider implements MeterBinder {
@@ -18,6 +19,7 @@ public class MicrometerMetricsProvider implements MeterBinder {
     }
 
     @Produces
+    @DefaultBean
     public Metrics getMetrics() {
         return metrics;
     }

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/NoOpMetricsProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/NoOpMetricsProvider.java
@@ -1,10 +1,9 @@
 package io.quarkiverse.operatorsdk.runtime;
 
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.quarkus.arc.DefaultBean;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class NoOpMetricsProvider {

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/NoOpMetricsProvider.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/NoOpMetricsProvider.java
@@ -4,10 +4,12 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
 
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.quarkus.arc.DefaultBean;
 
 @Singleton
 public class NoOpMetricsProvider {
     @Produces
+    @DefaultBean
     public Metrics getMetrics() {
         return Metrics.NOOP;
     }

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorHealthCheck.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorHealthCheck.java
@@ -1,13 +1,12 @@
 package io.quarkiverse.operatorsdk.runtime;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.Readiness;
 
 import io.javaoperatorsdk.operator.Operator;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @Readiness
 @ApplicationScoped

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorProducer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/OperatorProducer.java
@@ -2,10 +2,6 @@ package io.quarkiverse.operatorsdk.runtime;
 
 import static io.quarkiverse.operatorsdk.runtime.CRDUtils.applyCRD;
 
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.Produces;
-import javax.inject.Singleton;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +10,9 @@ import io.javaoperatorsdk.operator.Operator;
 import io.javaoperatorsdk.operator.api.config.ConfigurationServiceProvider;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.quarkus.arc.DefaultBean;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class OperatorProducer {

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <artifactId>quarkus-operator-sdk-integration-tests</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
@@ -44,6 +46,11 @@
     <dependency>
       <groupId>io.fabric8</groupId>
       <artifactId>istio-model-v1beta1</artifactId>
+    </dependency>
+    <!--  to check that MeterRegistry are properly bound to custom Metrics implementations -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/ApplicationScopedReconciler.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/ApplicationScopedReconciler.java
@@ -1,11 +1,10 @@
 package io.quarkiverse.operatorsdk.it;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 @ControllerConfiguration(name = ApplicationScopedReconciler.NAME)

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
@@ -8,13 +8,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -31,6 +24,12 @@ import io.javaoperatorsdk.operator.processing.retry.Retry;
 import io.quarkiverse.operatorsdk.runtime.QuarkusConfigurationService;
 import io.quarkiverse.operatorsdk.runtime.QuarkusControllerConfiguration;
 import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
 
 @SuppressWarnings("unused")
 @Path("/operator")

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/OperatorSDKResource.java
@@ -134,6 +134,22 @@ public class OperatorSDKResource {
         public boolean apply() {
             return conf.getCRDGenerationInfo().isApplyCRDs();
         }
+
+        @JsonProperty("metrics")
+        public String metrics() {
+            return conf.getMetrics().getClass().getName();
+        }
+
+        @JsonProperty("registryBound")
+        public boolean registryBound() {
+            final var metrics = conf.getMetrics();
+            return metrics instanceof TestMetrics && ((TestMetrics) metrics).isRegistryBound();
+        }
+
+        @JsonProperty("leaderConfig")
+        public String leaderConfig() {
+            return conf.getLeaderElectionConfiguration().map(lec -> lec.getClass().getName()).orElse(null);
+        }
     }
 
     static class JSONControllerConfiguration {

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestLeaderElectionConfiguration.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestLeaderElectionConfiguration.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.operatorsdk.it;
+
+import javax.inject.Singleton;
+
+import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
+
+@Singleton
+public class TestLeaderElectionConfiguration extends LeaderElectionConfiguration {
+
+    public TestLeaderElectionConfiguration() {
+        super("testLeaseName");
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestLeaderElectionConfiguration.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestLeaderElectionConfiguration.java
@@ -1,8 +1,7 @@
 package io.quarkiverse.operatorsdk.it;
 
-import javax.inject.Singleton;
-
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class TestLeaderElectionConfiguration extends LeaderElectionConfiguration {

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestMetrics.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestMetrics.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.operatorsdk.it;
+
+import javax.inject.Singleton;
+
+import io.javaoperatorsdk.operator.api.monitoring.Metrics;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+@Singleton
+public class TestMetrics implements Metrics, MeterBinder {
+    private boolean registryBound;
+
+    @Override
+    public void bindTo(MeterRegistry meterRegistry) {
+        registryBound = true;
+    }
+
+    public boolean isRegistryBound() {
+        return registryBound;
+    }
+}

--- a/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestMetrics.java
+++ b/integration-tests/src/main/java/io/quarkiverse/operatorsdk/it/TestMetrics.java
@@ -1,10 +1,9 @@
 package io.quarkiverse.operatorsdk.it;
 
-import javax.inject.Singleton;
-
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class TestMetrics implements Metrics, MeterBinder {

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -13,5 +13,6 @@ quarkus.operator-sdk.concurrent-reconciliation-threads=10
 quarkus.operator-sdk.termination-timeout-seconds=20
 quarkus.operator-sdk.crd.validate=false
 quarkus.operator-sdk.crd.versions=v1beta1
+quarkus.operator-sdk.activate-leader-election-for-profiles=prod,test,dev
 ## activate to prevent the operator to start when debugging tests (note that some tests might fail because of this)
 quarkus.operator-sdk.start-operator=false

--- a/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/operatorsdk/it/OperatorSDKResourceTest.java
@@ -66,6 +66,18 @@ class OperatorSDKResourceTest {
     }
 
     @Test
+    void shouldHaveCustomMetricsImplementationIfDefined() {
+        given().when().get("/operator/config").then().statusCode(200).body(
+                "registryBound", equalTo(true));
+    }
+
+    @Test
+    void shouldOnlyHaveLeaderElectionActivatedInRequestedModes() {
+        given().when().get("/operator/config").then().statusCode(200).body(
+                "leaderConfig", equalTo(TestLeaderElectionConfiguration.class.getName()));
+    }
+
+    @Test
     void controllerShouldExist() {
         // first check that we're not always returning true for any controller name :)
         given().when().get("/operator/does_not_exist").then().statusCode(200).body(is("false"));

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
   <name>Quarkus - Operator SDK - Parent</name>
   <properties>
-    <quarkus.version>999-SNAPSHOT</quarkus.version>
+    <quarkus.version>3.0.0.Alpha4</quarkus.version>
     <java-operator-sdk.version>4.3.0-SNAPSHOT</java-operator-sdk.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>io.quarkiverse.operatorsdk</groupId>
   <artifactId>quarkus-operator-sdk-parent</artifactId>
-  <version>5.1.0-SNAPSHOT</version>
+  <version>6.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Quarkus - Operator SDK - Parent</name>
   <properties>

--- a/samples/exposedapp/pom.xml
+++ b/samples/exposedapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
     <groupId>io.quarkiverse.operatorsdk</groupId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/samples/exposedapp/src/test/java/io/halkyon/ExposedAppReconcilerTest.java
+++ b/samples/exposedapp/src/test/java/io/halkyon/ExposedAppReconcilerTest.java
@@ -7,8 +7,6 @@ import static org.hamcrest.Matchers.nullValue;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Inject;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
@@ -18,6 +16,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 
 @QuarkusTest
 class ExposedAppReconcilerTest {

--- a/samples/joke/pom.xml
+++ b/samples/joke/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/samples/joke/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconciler.java
+++ b/samples/joke/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconciler.java
@@ -19,8 +19,6 @@ import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_CURRENT
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
@@ -32,6 +30,7 @@ import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadata;
 import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadata.Icon;
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestSpec.ExcludedTopic;
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestStatus.State;
+import jakarta.inject.Inject;
 
 @CSVMetadata(permissionRules = @CSVMetadata.PermissionRule(apiGroups = Joke.GROUP, resources = "jokes"), requiredCRDs = @CSVMetadata.RequiredCRD(kind = "Joke", name = Joke.NAME, version = Joke.VERSION), icon = @Icon(fileName = "icon.png", mediatype = "image/png"))
 @ControllerConfiguration(namespaces = WATCH_CURRENT_NAMESPACE)

--- a/samples/joke/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeService.java
+++ b/samples/joke/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeService.java
@@ -14,17 +14,16 @@
  */
 package io.quarkiverse.operatorsdk.samples.joke;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 import org.jboss.resteasy.reactive.RestPath;
 import org.jboss.resteasy.reactive.RestQuery;
 
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestSpec.Category;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 
 @ApplicationScoped
 @RegisterRestClient(configKey = "joke-api")

--- a/samples/joke/src/test/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconcilerTest.java
+++ b/samples/joke/src/test/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconcilerTest.java
@@ -14,8 +14,6 @@ import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.Map;
 
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -27,6 +25,7 @@ import io.quarkiverse.operatorsdk.samples.joke.JokeRequestSpec.Category;
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestStatus.State;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectMock;
+import jakarta.inject.Inject;
 
 @QuarkusTest
 class JokeRequestReconcilerTest {

--- a/samples/mysql-schema/pom.xml
+++ b/samples/mysql-schema/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-operator-sdk-samples-mysql-schema</artifactId>

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaReconciler.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaReconciler.java
@@ -3,8 +3,6 @@ package io.quarkiverse.operatorsdk.samples.mysqlschema;
 import static io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SchemaDependentResource.decode;
 import static io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentResource.MYSQL_SECRET_USERNAME;
 
-import javax.inject.Inject;
-
 import io.fabric8.kubernetes.api.model.Secret;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
@@ -18,6 +16,7 @@ import io.quarkiverse.operatorsdk.samples.mysqlschema.dependent.SecretDependentR
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
 import io.quarkus.logging.Log;
+import jakarta.inject.Inject;
 
 @ControllerConfiguration(dependents = {
         @Dependent(type = SecretDependentResource.class),

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaDependentResource.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SchemaDependentResource.java
@@ -10,9 +10,6 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +23,8 @@ import io.javaoperatorsdk.operator.processing.dependent.external.PerResourcePoll
 import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class SchemaDependentResource

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
@@ -2,8 +2,6 @@ package io.quarkiverse.operatorsdk.samples.mysqlschema.dependent;
 
 import java.util.Base64;
 
-import javax.enterprise.context.ApplicationScoped;
-
 import org.apache.commons.lang3.RandomStringUtils;
 
 import io.fabric8.kubernetes.api.model.Secret;
@@ -13,6 +11,7 @@ import io.javaoperatorsdk.operator.processing.dependent.Creator;
 import io.javaoperatorsdk.operator.processing.dependent.Matcher.Result;
 import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
+import jakarta.enterprise.context.ApplicationScoped;
 
 @ApplicationScoped
 public class SecretDependentResource extends KubernetesDependentResource<Secret, MySQLSchema>

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/SchemaService.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/SchemaService.java
@@ -9,12 +9,11 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-
 import io.agroal.api.AgroalDataSource;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
 import io.quarkus.logging.Log;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class SchemaService {

--- a/samples/mysql-schema/src/test/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaOperatorE2ETest.java
+++ b/samples/mysql-schema/src/test/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaOperatorE2ETest.java
@@ -13,8 +13,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import javax.inject.Inject;
-
 import org.jboss.logging.Logger;
 import org.junit.jupiter.api.Test;
 
@@ -24,6 +22,7 @@ import io.javaoperatorsdk.operator.Operator;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
+import jakarta.inject.Inject;
 
 @QuarkusTest
 class MySQLSchemaOperatorE2ETest {

--- a/samples/pingpong/pom.xml
+++ b/samples/pingpong/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/samples/pingpong/src/main/java/io/quarkiverse/operatorsdk/samples/pingpong/PingReconciler.java
+++ b/samples/pingpong/src/main/java/io/quarkiverse/operatorsdk/samples/pingpong/PingReconciler.java
@@ -16,13 +16,12 @@ package io.quarkiverse.operatorsdk.samples.pingpong;
 
 import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_CURRENT_NAMESPACE;
 
-import javax.inject.Inject;
-
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import jakarta.inject.Inject;
 
 @ControllerConfiguration(namespaces = WATCH_CURRENT_NAMESPACE)
 @SuppressWarnings("unused")

--- a/samples/pingpong/src/test/java/io/quarkiverse/operatorsdk/samples/pingpong/PingPongReconcilerTest.java
+++ b/samples/pingpong/src/test/java/io/quarkiverse/operatorsdk/samples/pingpong/PingPongReconcilerTest.java
@@ -8,14 +8,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.notNullValue;
 
-import javax.inject.Inject;
-
 import org.junit.jupiter.api.Test;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 
 @QuarkusTest
 class PingPongReconcilerTest {

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>quarkus-operator-sdk-build-parent</artifactId>
     <groupId>io.quarkiverse.operatorsdk</groupId>
-    <version>5.1.0-SNAPSHOT</version>
+    <version>6.0.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
This update currently doesn't work because Quarkus 3.0.0.Alpha2 is based off of 2.14.3 when we need at least 2.15.0 to use the Kubernetes Dev Services. Should be addressed with Alpha3.