### PR TITLE
chore: update actions to handle deprecation warnings

### DIFF
--- a/.github/workflows/build-for-quarkus-version.yml
+++ b/.github/workflows/build-for-quarkus-version.yml
@@ -49,7 +49,7 @@ jobs:
         run: mvn -B formatter:validate install -Dnative --file pom.xml -Dquarkus.test.arg-line="-DNAMESPACE_FROM_ENV=fromEnvVarNS -DQUARKUS_OPERATOR_SDK_CONTROLLERS_EMPTY_NAMESPACES=fromEnv1,fromEnv2 -DVARIABLE_NS_ENV=variableNSFromEnv -DQUARKUS_OPERATOR_SDK_CONTROLLERS_KEYCLOAKCONTROLLER_NAMESPACES=keycloak-ns"
 
       - name: Kubernetes KinD Cluster
-        uses: container-tools/kind-action@v1
+        uses: container-tools/kind-action@v2
         with:
           version: v0.11.1
           registry: true

--- a/.github/workflows/build-for-quarkus-version.yml
+++ b/.github/workflows/build-for-quarkus-version.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "{date}={$(/bin/date -u "+%Y-%m")}" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Build with Maven (JVM)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
   #        run: |
   #          versions=$(curl https://registry.quarkus.io/client/platforms | jq '[.platforms[].streams[].releases[].version | select(endswith("Final"))]')
   #          echo "${versions}"
-  #          echo "::set-output name=matrix::${versions}"
+  #          echo "{matrix}=${versions}" >> $GITHUB_OUTPUT
   build-for-quarkus-version:
     #    needs: get-quarkus-versions
     strategy:


### PR DESCRIPTION
- chore: remove deprecated set-output usage
- chore: update kind-action to v2 to avoid nodejs 12 deprecation
