### PR TITLE
release 6.0.0.CR1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Java Operator SDK Extension
 release:
-  current-version: 5.0.2
-  next-version: 5.0.3-SNAPSHOT
+  current-version: 6.0.0.CR1
+  next-version: 6.0.0-SNAPSHOT
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         #        quarkus-version: ${{ fromJSON(needs.get-quarkus-versions.outputs.matrix) }}
-        quarkus-version: [ 3.0.0.Beta1 ]
+        quarkus-version: [ 3.0.0.CR1 ]
         java-version: [ 11, 17 ]
     uses: ./.github/workflows/build-for-quarkus-version.yml
     with:

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
       <id>ossrh</id>
       <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <updatePolicy>daily</updatePolicy>
       </snapshots>
     </repository>
@@ -32,7 +32,7 @@
       <id>ossrh</id>
       <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
       <snapshots>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
         <updatePolicy>daily</updatePolicy>
       </snapshots>
     </pluginRepository>


### PR DESCRIPTION
- chore: deactivate snapshots
- chore: use Quarkus 3.0.0.CR1 to build against
- chore: release 6.0.0.CR1
