### PR TITLE
fix: default to only emit warning on version misalignment

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Java Operator SDK Extension
 release:
-  current-version: 6.0.0
-  next-version: 6.0.1-SNAPSHOT
+  current-version: 6.0.1
+  next-version: 6.0.2-SNAPSHOT
 

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
@@ -61,7 +61,7 @@ public class BuildTimeOperatorConfiguration {
     /**
      * Whether to fail or only emit a warning on version validation at compile time.
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem(defaultValue = "false")
     public Boolean failOnVersionCheck;
 
     /**

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 6.0.0
+:project-version: 6.0.1
 
 :examples-dir: ./../examples/

--- a/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
@@ -215,7 +215,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPERATOR_SDK_FAIL_ON_VERSION_CHECK+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
-|`true`
+|`false`
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-operator-sdk_quarkus.operator-sdk.activate-leader-election-for-profiles]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.activate-leader-election-for-profiles[quarkus.operator-sdk.activate-leader-election-for-profiles]`


### PR DESCRIPTION
- fix: default to only emit warning on version misalignment
- chore: release 6.0.1
