### PR TITLE
DO NOT MERGE: nightly releases with fabric8/josdk nightlies

### DIFF
--- a/.github/workflows/build-for-quarkus-version.yml
+++ b/.github/workflows/build-for-quarkus-version.yml
@@ -143,7 +143,7 @@ jobs:
           git switch pr-to-check
           ./update-version.sh 999.${{ github.event.inputs.quarkus-pr }}-SNAPSHOT
           echo "quarkus_f8_version=$(./mvnw help:evaluate -Dexpression=kubernetes-client.version -q -DforceStdout)" >> $GITHUB_OUTPUT
-          ./mvnw -Dquickly
+          ./mvnw -Dquickly -Puse-snapshots
           cd -
 
       - name: Check-out Fabric8 client PR if requested

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,12 @@
 name: Build PRs and main when updated
 
 on:
+  schedule:
+    # daily run
+    - cron: '0 0 * * *'
   push:
     branches:
-      - "main"
+      - "next-fabric8-version"
     paths-ignore:
       - '.gitignore'
       - 'CODEOWNERS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,8 @@ jobs:
         java-version: [ 17, 21 ]
     uses: ./.github/workflows/build-for-quarkus-version.yml
     with:
-      quarkus-version: ${{ needs.extract-project-metadata.outputs.latest_stable_quarkus }}
+#      quarkus-version: ${{ needs.extract-project-metadata.outputs.latest_stable_quarkus }}
+      quarkus-version: 999-SNAPSHOT
       java-version: ${{ matrix.java-version }}
       branch: ${{ needs.extract-project-metadata.outputs.branch_name }}
       native-modules: "integration-tests"

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-client-bom</artifactId>
-        <version>6.10-SNAPSHOT</version>
+        <version>6.11-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,7 +43,7 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-client-bom</artifactId>
-        <version>6.11-SNAPSHOT</version>
+        <version>6.12-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -38,12 +38,16 @@
     <url>https://github.com/quarkiverse/quarkus-operator-sdk/issues/</url>
   </issueManagement>
 
+  <properties>
+    <fabric8-client.version>6.12-SNAPSHOT</fabric8-client.version>
+  </properties>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-client-bom</artifactId>
-        <version>6.12-SNAPSHOT</version>
+        <version>${fabric8-client.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -41,6 +41,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client-bom</artifactId>
+        <version>6.10-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-bom</artifactId>
         <version>${quarkus.version}</version>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -39,7 +39,7 @@
   </issueManagement>
 
   <properties>
-    <fabric8-client.version>6.12-SNAPSHOT</fabric8-client.version>
+    <fabric8-client.version>7.0-SNAPSHOT</fabric8-client.version>
   </properties>
 
   <dependencyManagement>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -16,6 +16,27 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+
+        <repository>
+            <id>oss-sonatype</id>
+            <name>oss-sonatype</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -35,6 +35,15 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+
+        <repository>
+            <id>oss-sonatype-quarkus</id>
+            <name>oss-sonatype-quarkus</name>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
   <dependencyManagement>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -21,7 +21,7 @@
       <dependency>
         <groupId>io.fabric8</groupId>
         <artifactId>kubernetes-client-bom</artifactId>
-        <version>6.8-SNAPSHOT</version>
+        <version>6.10-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -19,6 +19,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>io.fabric8</groupId>
+        <artifactId>kubernetes-client-bom</artifactId>
+        <version>6.8-SNAPSHOT</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-bom</artifactId>
         <version>${project.version}</version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -40,13 +40,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.fabric8</groupId>
-        <artifactId>kubernetes-client-bom</artifactId>
-        <version>6.10-SNAPSHOT</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-bom</artifactId>
         <version>${project.version}</version>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -17,35 +17,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
 
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-        </repository>
-
-        <repository>
-            <id>oss-sonatype</id>
-            <name>oss-sonatype</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-
-        <repository>
-            <id>oss-sonatype-quarkus</id>
-            <name>oss-sonatype-quarkus</name>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
   <dependencyManagement>
     <dependencies>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,17 @@
     </repository>
   </repositories>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>oss-sonatype-quarkus</id>
+      <name>oss-sonatype-quarkus</name>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </pluginRepository>
+  </pluginRepositories>
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,35 @@
     <tag>HEAD</tag>
   </scm>
 
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>central</id>
+      <name>Central Repository</name>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+
+    <repository>
+      <id>oss-sonatype</id>
+      <name>oss-sonatype</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+
+    <repository>
+      <id>oss-sonatype-quarkus</id>
+      <name>oss-sonatype-quarkus</name>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -21,49 +21,6 @@
     <url>https://github.com/quarkiverse/quarkus-operator-sdk</url>
     <tag>HEAD</tag>
   </scm>
-
-  <repositories>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>central</id>
-      <name>Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-    </repository>
-
-    <repository>
-      <id>oss-sonatype</id>
-      <name>oss-sonatype</name>
-      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-
-    <repository>
-      <id>oss-sonatype-quarkus</id>
-      <name>oss-sonatype-quarkus</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </snapshots>
-    </repository>
-  </repositories>
-
-  <pluginRepositories>
-    <pluginRepository>
-      <id>oss-sonatype-quarkus</id>
-      <name>oss-sonatype-quarkus</name>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
       <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
 
@@ -47,6 +48,7 @@
       <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
       <snapshots>
         <enabled>true</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <url>https://github.com/quarkiverse/quarkus-operator-sdk</url>
     <tag>HEAD</tag>
   </scm>
+
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>


### PR DESCRIPTION
This PR is meant to produce nightly builds using the latest nightly builds of the fabric8 client and JOSDK, produced version is `999.F8-SNAPSHOT`.