### PR TITLE
feat: natively build samples in parallel

### DIFF
--- a/.github/workflows/build-for-quarkus-version.yml
+++ b/.github/workflows/build-for-quarkus-version.yml
@@ -47,7 +47,7 @@ jobs:
         run: mvn -B formatter:validate install --file pom.xml
 
       - name: Build with Maven (Native)
-        run: mvn -B formatter:validate install -Dnative --file pom.xml -pl '${{inputs.native-modules}}' -amd
+        run: mvn -B install -Dnative --file pom.xml -pl '${{inputs.native-modules}}' -amd
 
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v2

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -25,17 +25,6 @@
         <sourceDirectory>modules/ROOT/examples</sourceDirectory>
         <plugins>
             <plugin>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>it.ozimov</groupId>
                 <artifactId>yaml-properties-maven-plugin</artifactId>
                 <executions>

--- a/samples/exposedapp/src/main/resources/application.properties
+++ b/samples/exposedapp/src/main/resources/application.properties
@@ -7,4 +7,4 @@ quarkus.kubernetes-client.devservices.override-kubeconfig=true
 %test.quarkus.operator-sdk.close-client-on-stop=false
 %test.quarkus.operator-sdk.start-operator=true
 quarkus.kubernetes-client.devservices.flavor=k3s
-quarkus.http.test-port=8081
+quarkus.http.test-port=0

--- a/samples/exposedapp/src/main/resources/application.properties
+++ b/samples/exposedapp/src/main/resources/application.properties
@@ -7,3 +7,4 @@ quarkus.kubernetes-client.devservices.override-kubeconfig=true
 %test.quarkus.operator-sdk.close-client-on-stop=false
 %test.quarkus.operator-sdk.start-operator=true
 quarkus.kubernetes-client.devservices.flavor=k3s
+quarkus.http.test-port=8081

--- a/samples/joke/src/main/resources/application.properties
+++ b/samples/joke/src/main/resources/application.properties
@@ -5,4 +5,4 @@ quarkus.operator-sdk.bundle.channels=alpha
 quarkus.operator-sdk.bundle.package-name=joke-operator
 quarkus.operator-sdk.crd.generate-all=true
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
-quarkus.http.test-port=8082
+quarkus.http.test-port=0

--- a/samples/joke/src/main/resources/application.properties
+++ b/samples/joke/src/main/resources/application.properties
@@ -5,3 +5,4 @@ quarkus.operator-sdk.bundle.channels=alpha
 quarkus.operator-sdk.bundle.package-name=joke-operator
 quarkus.operator-sdk.crd.generate-all=true
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
+quarkus.http.test-port=8082

--- a/samples/mysql-schema/src/main/resources/application.properties
+++ b/samples/mysql-schema/src/main/resources/application.properties
@@ -4,3 +4,4 @@ quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.commons
 quarkus.datasource.username=root
 quarkus.datasource.devservices.image-name=mariadb:10.7
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
+quarkus.http.test-port=8083

--- a/samples/mysql-schema/src/main/resources/application.properties
+++ b/samples/mysql-schema/src/main/resources/application.properties
@@ -4,4 +4,4 @@ quarkus.native.additional-build-args=--initialize-at-run-time=org.apache.commons
 quarkus.datasource.username=root
 quarkus.datasource.devservices.image-name=mariadb:10.7
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
-quarkus.http.test-port=8083
+quarkus.http.test-port=0

--- a/samples/pingpong/src/main/resources/application.properties
+++ b/samples/pingpong/src/main/resources/application.properties
@@ -3,4 +3,4 @@ quarkus.container-image.builder=jib
 quarkus.operator-sdk.bundle.channels=alpha
 quarkus.operator-sdk.bundle.package-name=pingpong-operator
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
-quarkus.http.test-port=8084
+quarkus.http.test-port=0

--- a/samples/pingpong/src/main/resources/application.properties
+++ b/samples/pingpong/src/main/resources/application.properties
@@ -3,3 +3,4 @@ quarkus.container-image.builder=jib
 quarkus.operator-sdk.bundle.channels=alpha
 quarkus.operator-sdk.bundle.package-name=pingpong-operator
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
+quarkus.http.test-port=8084


### PR DESCRIPTION
- fix: remove unneeded Quarkus plugin
- refactor: make it possible to run the tests in parallel
- refactor: only natively build tests and samples, in parallel
