### PR TITLE
Enable OperatorSDKTest

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -82,6 +82,14 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
+          <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
@@ -13,7 +13,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -37,7 +36,6 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-@Disabled
 public class OperatorSDKTest {
 
     // Start unit test with your extension loaded


### PR DESCRIPTION
The reason it was previously failing is that
Dekorate could not find a valid Maven project
in the temp directory in which QuarkusProdModeTest bootstraps the Quarkus application.
In order to make it work, we need to ensure that
the aforementioned temp directory is created under the project root, so Dekorate then finds it by moving up the file system.

The same thing is done in the Quarkus repo to
make the Kubernetes related QuarkusProdModeTest
tests work.
The reason argLine is used instead of systemProperties is mentioned in the comment