### PR TITLE
refactor: split configuration & CRD generation steps

### DIFF
--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/ConfigurationUtils.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/ConfigurationUtils.java
@@ -2,10 +2,14 @@ package io.quarkiverse.operatorsdk.common;
 
 import static io.quarkiverse.operatorsdk.common.Constants.CONTROLLER_CONFIGURATION;
 
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import io.quarkus.bootstrap.app.ClassChangeInformation;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
@@ -136,5 +140,11 @@ public class ConfigurationUtils {
         final var defaultControllerName = ReconcilerUtils.getDefaultReconcilerName(reconcilerClassName);
         return ConfigurationUtils.annotationValueOrDefault(
                 configuration, "name", AnnotationValue::asString, () -> defaultControllerName);
+    }
+
+    public static Set<String> getChangedClasses(LiveReloadBuildItem liveReload) {
+       return liveReload.isLiveReload() ? Optional.ofNullable(liveReload.getChangeInformation())
+                .map(ClassChangeInformation::getChangedClasses)
+                .orElse(Collections.emptySet()) : Collections.emptySet();
     }
 }

--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/ConfigurationUtils.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/ConfigurationUtils.java
@@ -8,8 +8,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import io.quarkus.bootstrap.app.ClassChangeInformation;
-import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
@@ -17,6 +15,8 @@ import org.jboss.jandex.IndexView;
 
 import io.javaoperatorsdk.operator.ReconcilerUtils;
 import io.javaoperatorsdk.operator.api.config.Utils;
+import io.quarkus.bootstrap.app.ClassChangeInformation;
+import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 
 public class ConfigurationUtils {
 
@@ -143,7 +143,7 @@ public class ConfigurationUtils {
     }
 
     public static Set<String> getChangedClasses(LiveReloadBuildItem liveReload) {
-       return liveReload.isLiveReload() ? Optional.ofNullable(liveReload.getChangeInformation())
+        return liveReload.isLiveReload() ? Optional.ofNullable(liveReload.getChangeInformation())
                 .map(ClassChangeInformation::getChangedClasses)
                 .orElse(Collections.emptySet()) : Collections.emptySet();
     }

--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/Constants.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/Constants.java
@@ -2,8 +2,6 @@ package io.quarkiverse.operatorsdk.common;
 
 import org.jboss.jandex.DotName;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.javaoperatorsdk.operator.api.config.AnnotationConfigurable;
@@ -12,7 +10,6 @@ import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Ignore;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
-import io.quarkus.kubernetes.client.KubernetesClientObjectMapper;
 
 public class Constants {
     private Constants() {
@@ -27,6 +24,4 @@ public class Constants {
     public static final DotName CONFIGURED = DotName.createSimple(Configured.class.getName());
     public static final DotName ANNOTATION_CONFIGURABLE = DotName.createSimple(AnnotationConfigurable.class.getName());
     public static final DotName OBJECT = DotName.createSimple(Object.class.getName());
-    public static final DotName OBJECT_MAPPER = DotName.createSimple(ObjectMapper.class);
-    public static final DotName KUBERNETES_CLIENT_OBJECT_MAPPER = DotName.createSimple(KubernetesClientObjectMapper.class);
 }

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/AnnotationConfigurablesBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/AnnotationConfigurablesBuildItem.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.operatorsdk.deployment;
+
+import java.util.Map;
+
+import io.quarkiverse.operatorsdk.common.AnnotationConfigurableAugmentedClassInfo;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class AnnotationConfigurablesBuildItem extends SimpleBuildItem {
+
+    private final Map<String, AnnotationConfigurableAugmentedClassInfo> configurableInfos;
+
+    public AnnotationConfigurablesBuildItem(
+            Map<String, AnnotationConfigurableAugmentedClassInfo> configurableInfos) {
+        this.configurableInfos = configurableInfos;
+    }
+
+    public Map<String, AnnotationConfigurableAugmentedClassInfo> getConfigurableInfos() {
+        return configurableInfos;
+    }
+}

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.jboss.logging.Logger;
+
 import io.fabric8.crd.generator.CRDGenerator;
 import io.fabric8.crd.generator.CustomResourceInfo;
 import io.fabric8.kubernetes.client.CustomResource;
@@ -21,6 +23,7 @@ import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 import io.quarkus.runtime.LaunchMode;
 
 class CRDGeneration {
+    private static final Logger log = Logger.getLogger(CRDGeneration.class.getName());
     private CRDGenerator generator;
     private final LaunchMode mode;
     private final CRDConfiguration crdConfiguration;
@@ -82,7 +85,7 @@ class CRDGeneration {
             final var crdDetailsPerNameAndVersion = info.getCRDDetailsPerNameAndVersion();
 
             crdDetailsPerNameAndVersion.forEach((crdName, initialVersionToCRDInfoMap) -> {
-                OperatorSDKProcessor.log.infov("Generated {0} CRD:", crdName);
+                log.infov("Generated {0} CRD:", crdName);
                 generated.add(crdName);
 
                 final var versions = crMappings.getResourceInfos(crdName);
@@ -90,7 +93,7 @@ class CRDGeneration {
                 initialVersionToCRDInfoMap
                         .forEach((version, crdInfo) -> {
                             final var filePath = crdInfo.getFilePath();
-                            OperatorSDKProcessor.log.infov("  - {0} -> {1}", version, filePath);
+                            log.infov("  - {0} -> {1}", version, filePath);
                             versionToCRDInfo.put(version, new CRDInfo(crdInfo.getCrdName(),
                                     version, filePath, crdInfo.getDependentClassNames(), versions));
                         });
@@ -118,7 +121,7 @@ class CRDGeneration {
             }
 
             // we've looked at all the changed classes and none have been changed for this CR/version: do not regenerate CRD
-            OperatorSDKProcessor.log.infov(
+            log.infov(
                     "''{0}'' CRD generation was skipped for ''{1}'' because no changes impacting the CRD were detected",
                     v, targetCRName);
             generateCurrent[0] = false;

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
@@ -22,17 +22,14 @@ import io.quarkus.runtime.LaunchMode;
 
 class CRDGeneration {
     private CRDGenerator generator;
-    private final boolean generate;
     private final LaunchMode mode;
     private final CRDConfiguration crdConfiguration;
-
     private boolean needGeneration;
     private final ResourceControllerMapping crMappings = new ResourceControllerMapping();
 
     public CRDGeneration(CRDConfiguration crdConfig, LaunchMode mode) {
         this.crdConfiguration = crdConfig;
         this.mode = mode;
-        this.generate = CRDGeneration.shouldGenerate(crdConfig.generate, crdConfig.apply, mode);
     }
 
     static boolean shouldGenerate(Optional<Boolean> configuredGenerate, Optional<Boolean> configuredApply,
@@ -49,10 +46,6 @@ class CRDGeneration {
 
     boolean shouldApply() {
         return shouldApply(crdConfiguration.apply, mode);
-    }
-
-    public boolean wantCRDGenerated() {
-        return generate;
     }
 
     /**

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationBuildStep.java
@@ -3,6 +3,7 @@ package io.quarkiverse.operatorsdk.deployment;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 import org.jboss.logging.Logger;
 
@@ -18,11 +19,26 @@ import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
 import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
+import io.quarkus.runtime.LaunchMode;
 
 public class CRDGenerationBuildStep {
     static final Logger log = Logger.getLogger(CRDGenerationBuildStep.class.getName());
 
-    @BuildStep
+    private static class WantCRDGenerated implements BooleanSupplier {
+
+        private final boolean generate;
+
+        private WantCRDGenerated(BuildTimeOperatorConfiguration config, LaunchMode launchMode) {
+            generate = CRDGeneration.shouldGenerate(config.crd.generate, config.crd.apply, launchMode);
+        }
+
+        @Override
+        public boolean getAsBoolean() {
+            return generate;
+        }
+    }
+
+    @BuildStep(onlyIf = WantCRDGenerated.class)
     GeneratedCRDInfoBuildItem generateCRDs(
             ReconcilerInfosBuildItem reconcilers,
             BuildTimeOperatorConfiguration buildTimeConfiguration,
@@ -31,12 +47,10 @@ public class CRDGenerationBuildStep {
             OutputTargetBuildItem outputTarget,
             CombinedIndexBuildItem combinedIndexBuildItem) {
         final var crdConfig = buildTimeConfiguration.crd;
-        final boolean validateCustomResources = ConfigurationUtils.shouldValidateCustomResources(
-                buildTimeConfiguration.crd.validate);
+        final boolean validateCustomResources = ConfigurationUtils.shouldValidateCustomResources(crdConfig.validate);
 
         //apply should imply generate:we cannot apply if we 're not generating!
-        final var mode = launchMode.getLaunchMode();
-        final var crdGeneration = new CRDGeneration(crdConfig, mode);
+        final var crdGeneration = new CRDGeneration(crdConfig, launchMode.getLaunchMode());
 
         // retrieve the known CRD information to make sure we always have a full view
         var stored = liveReload.getContextObject(ContextStoredCRDInfos.class);
@@ -45,33 +59,29 @@ public class CRDGenerationBuildStep {
         }
         final var storedCRDInfos = stored;
         final var changedClasses = ConfigurationUtils.getChangedClasses(liveReload);
-        final var wantCRDGenerated = crdGeneration.wantCRDGenerated();
         final var scheduledForGeneration = new HashSet<String>(7);
 
         reconcilers.getReconcilers().values().stream().forEach(raci -> {
             // add associated primary resource for CRD generation if needed
-            final var changeInformation = liveReload.getChangeInformation();
-            if (wantCRDGenerated) {
-                if (raci.associatedResourceInfo().isCR()) {
-                    final var crInfo = raci.associatedResourceInfo().asResourceTargeting();
-                    // When we have a live reload, check if we need to regenerate the associated CRD
-                    Map<String, CRDInfo> crdInfos = Collections.emptyMap();
+            if (raci.associatedResourceInfo().isCR()) {
+                final var crInfo = raci.associatedResourceInfo().asResourceTargeting();
+                // When we have a live reload, check if we need to regenerate the associated CRD
+                Map<String, CRDInfo> crdInfos = Collections.emptyMap();
 
-                    final String targetCRName = crInfo.fullResourceName();
-                    if (liveReload.isLiveReload()) {
-                        crdInfos = storedCRDInfos.getCRDInfosFor(targetCRName);
-                    }
+                final String targetCRName = crInfo.fullResourceName();
+                if (liveReload.isLiveReload()) {
+                    crdInfos = storedCRDInfos.getCRDInfosFor(targetCRName);
+                }
 
-                    if (crdGeneration.scheduleForGenerationIfNeeded((CustomResourceAugmentedClassInfo) crInfo, crdInfos,
-                            changedClasses)) {
-                        scheduledForGeneration.add(targetCRName);
-                    }
+                if (crdGeneration.scheduleForGenerationIfNeeded((CustomResourceAugmentedClassInfo) crInfo, crdInfos,
+                        changedClasses)) {
+                    scheduledForGeneration.add(targetCRName);
                 }
             }
         });
 
         // generate non-reconciler associated CRDs if requested
-        if (wantCRDGenerated && crdConfig.generateAll) {
+        if (crdConfig.generateAll) {
             ClassUtils.getProcessableSubClassesOf(Constants.CUSTOM_RESOURCE, combinedIndexBuildItem.getIndex(), log,
                     // pass already generated CRD names so that we can only keep the unhandled ones
                     Map.of(CustomResourceAugmentedClassInfo.EXISTING_CRDS_KEY, scheduledForGeneration))

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationBuildStep.java
@@ -39,6 +39,7 @@ public class CRDGenerationBuildStep {
     }
 
     @BuildStep(onlyIf = WantCRDGenerated.class)
+    @SuppressWarnings("unused")
     GeneratedCRDInfoBuildItem generateCRDs(
             ReconcilerInfosBuildItem reconcilers,
             BuildTimeOperatorConfiguration buildTimeConfiguration,
@@ -49,7 +50,7 @@ public class CRDGenerationBuildStep {
         final var crdConfig = buildTimeConfiguration.crd;
         final boolean validateCustomResources = ConfigurationUtils.shouldValidateCustomResources(crdConfig.validate);
 
-        //apply should imply generate:we cannot apply if we 're not generating!
+        //apply should imply generate: we cannot apply if we 're not generating!
         final var crdGeneration = new CRDGeneration(crdConfig, launchMode.getLaunchMode());
 
         // retrieve the known CRD information to make sure we always have a full view
@@ -61,7 +62,7 @@ public class CRDGenerationBuildStep {
         final var changedClasses = ConfigurationUtils.getChangedClasses(liveReload);
         final var scheduledForGeneration = new HashSet<String>(7);
 
-        reconcilers.getReconcilers().values().stream().forEach(raci -> {
+        reconcilers.getReconcilers().values().forEach(raci -> {
             // add associated primary resource for CRD generation if needed
             if (raci.associatedResourceInfo().isCR()) {
                 final var crInfo = raci.associatedResourceInfo().asResourceTargeting();

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -170,9 +170,7 @@ class OperatorSDKProcessor {
         }
         final var storedCRDInfos = stored;
 
-        final Set<String> changedClasses = liveReload.isLiveReload() ? Optional.ofNullable(liveReload.getChangeInformation())
-                .map(ClassChangeInformation::getChangedClasses)
-                .orElse(Collections.emptySet()) : Collections.emptySet();
+        final var changedClasses = ConfigurationUtils.getChangedClasses(liveReload);
 
         final var wantCRDGenerated = crdGeneration.wantCRDGenerated();
         final var scheduledForGeneration = new HashSet<String>(7);

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -44,7 +44,7 @@ import io.quarkus.runtime.metrics.MetricsFactory;
 @SuppressWarnings({ "unused" })
 class OperatorSDKProcessor {
 
-    static final Logger log = Logger.getLogger(OperatorSDKProcessor.class.getName());
+    private static final Logger log = Logger.getLogger(OperatorSDKProcessor.class.getName());
 
     private static final String FEATURE = "operator-sdk";
     private static final String DEFAULT_METRIC_BINDER_CLASS_NAME = "io.quarkiverse.operatorsdk.runtime.MicrometerMetricsProvider";

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/QOSDKReflectiveClassBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/QOSDKReflectiveClassBuildItem.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.operatorsdk.deployment;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import io.quarkus.builder.item.MultiBuildItem;
+
+final class QOSDKReflectiveClassBuildItem extends MultiBuildItem {
+
+    private final List<String> classNamesToRegisterForReflection;
+
+    public QOSDKReflectiveClassBuildItem(List<String> classNamesToRegisterForReflection) {
+        this(classNamesToRegisterForReflection.toArray(new String[0]));
+    }
+
+    public QOSDKReflectiveClassBuildItem(String... classNameToRegisterForReflection) {
+        this.classNamesToRegisterForReflection = List.of(classNameToRegisterForReflection);
+    }
+
+    public Stream<String> classNamesToRegisterForReflectionStream() {
+        return classNamesToRegisterForReflection.stream();
+    }
+}

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/ReconcilerInfosBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/ReconcilerInfosBuildItem.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.operatorsdk.deployment;
+
+import java.util.Map;
+
+import io.quarkiverse.operatorsdk.common.ReconcilerAugmentedClassInfo;
+import io.quarkus.builder.item.SimpleBuildItem;
+
+final class ReconcilerInfosBuildItem extends SimpleBuildItem {
+    private final Map<String, ReconcilerAugmentedClassInfo> reconcilers;
+
+    public ReconcilerInfosBuildItem(Map<String, ReconcilerAugmentedClassInfo> reconcilers) {
+        this.reconcilers = reconcilers;
+    }
+
+    public Map<String, ReconcilerAugmentedClassInfo> getReconcilers() {
+        return reconcilers;
+    }
+}


### PR DESCRIPTION
Separate the configuration and CRD generation steps in the
deployment process and introduce new build items to support it.
Now reconcilers, annotation configurables, classes for reflection,
and dependent beans are managed in separate steps. This refactoring
improves maintainability and simplifies the Operator SDK Processor.

- refactor: lazily initialize CRD generator
- refactor: extract configuration creation logic
- refactor: remove unneeded constants
- refactor: extract changed classes extraction logic
- refactor: move application handling to own step
- refactor: split configuration & CRD generation steps
