### PR TITLE
fix: ensure that GeneratedCRDInfoBuildItem is always available

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
@@ -53,7 +53,9 @@ class CRDGeneration {
 
     /**
      * Generates the CRD in the location specified by the output target, using the specified CRD
-     * generation configuration
+     * generation configuration only if generation has been requested by call
+     * {@link #scheduleForGenerationIfNeeded(CustomResourceAugmentedClassInfo, Map, Set)} or
+     * {@link #withCustomResource(Class, String, String)}
      *
      * @param outputTarget the {@link OutputTargetBuildItem} specifying where the CRDs
      *        should be generated

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/NoCRDGenerationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/NoCRDGenerationTest.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.operatorsdk.test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.quarkiverse.operatorsdk.test.sources.*;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class NoCRDGenerationTest {
+
+    // Start unit test with your extension loaded
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setApplicationName("test")
+            .withApplicationRoot(
+                    (jar) -> jar.addClasses(SimpleReconciler.class, SimpleCR.class, SimpleSpec.class, SimpleStatus.class))
+            .overrideConfigKey("quarkus.operator-sdk.crd.generate", "false");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    public void shouldCreateRolesAndRoleBindings() throws IOException {
+        final var kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        final var kubeManifest = kubernetesDir.resolve("kubernetes.yml");
+        Assertions.assertTrue(Files.exists(kubeManifest));
+
+        // checks that CRDs are NOT generated
+        Assertions.assertFalse(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(TestCR.class) + "-v1.yml")));
+        Assertions.assertFalse(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(SimpleCR.class) + "-v1.yml")));
+    }
+}

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.rbac.ClusterRole;
+import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import io.quarkiverse.operatorsdk.deployment.AddClusterRolesDecorator;
 import io.quarkiverse.operatorsdk.test.sources.CRUDConfigMap;
@@ -54,8 +55,8 @@ public class OperatorSDKTest {
 
     @Test
     public void shouldCreateRolesAndRoleBindings() throws IOException {
-        final var kubeManifest = prodModeTestResults.getBuildDir().resolve("kubernetes")
-                .resolve("kubernetes.yml");
+        final var kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
+        final var kubeManifest = kubernetesDir.resolve("kubernetes.yml");
         Assertions.assertTrue(Files.exists(kubeManifest));
         final var kubeIS = new FileInputStream(kubeManifest.toFile());
         // use unmarshall version with parameters map to ensure code goes through the proper processing wrt multiple documents
@@ -120,5 +121,9 @@ public class OperatorSDKTest {
                     assertEquals(List.of(plural, plural + "/status", plural + "/finalizers"), resources);
                     assertEquals(Arrays.asList(ALL_VERBS), rule.getVerbs());
                 });
+
+        // checks that CRDs are generated
+        Assertions.assertTrue(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(TestCR.class) + "-v1.yml")));
+        Assertions.assertTrue(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(SimpleCR.class) + "-v1.yml")));
     }
 }


### PR DESCRIPTION
The item wasn't previously created if CRD generation was disabled, which
prevented the build to proceed normally.
