### PR TITLE
docs: improve documentation

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -16,7 +16,7 @@ Please also refer to the https://javaoperatorsdk.io/docs/getting-started[JOSDK d
 - Automatically registers reconcilers with the `Operator` and start them
 - Automatically generates CRDs for all `CustomResource` implementations used by reconcilers
 - Automatically generates Kubernetes descriptors
-- Automatically generates the bundle manifests for all reconcilers (using the `quarkus-operator-sdk-bundle-generator` extension) [Preview]
+- Automatically generates the bundle manifests for all reconcilers (using the `quarkus-operator-sdk-bundle-generator` extension)
 - Integrates with the Dev mode:
 * Watches your code for changes and reload automatically your operator if needed without having to hit an endpoint
 * Only re-generates the CRDs if a change impacting its generation is detected

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,6 +4,9 @@ include::./includes/attributes.adoc[]
 
 This extension integrates the https://javaoperatorsdk.io[Java Operator SDK] project (JOSDK) with Quarkus, making it even easier to use both.
 
+For an introduction to this project, please read the https://developers.redhat.com/articles/2022/02/15/write-kubernetes-java-java-operator-sdk[blog series] that we wrote on how to write operators in Java with Quarkus.
+Please also refer to the https://javaoperatorsdk.io/docs/getting-started[JOSDK documentation] for more details.
+
 == Features
 
 - Automatically generates a main class, so that the only thing that's required is to write `Reconciler` implementation(s)

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -25,7 +25,8 @@ Please also refer to the https://javaoperatorsdk.io/docs/getting-started[JOSDK d
 - Supports micrometer registry extensions (adding a Quarkus-supported micrometer registry extension will automatically inject said registry into the operator)
 - Automatically adds a SmallRye health check
 - Sets up reflection for native binary generation
-- Customize the JSON serialization that the Fabric8 client relies on by providing an `ObjectMapperCustomizer` implementation, qualified with the `@KubernetesClientSerializationCustomizer` annotation
+- [Deprecated] Customize the JSON serialization that the Fabric8 client relies on by providing an `ObjectMapperCustomizer` implementation, qualified with the `@KubernetesClientSerializationCustomizer` annotation
+* The Quarkus kubernetes client extension now provides an official mechanism to do so by implementing the `io.quarkus.kubernetes.client.KubernetesClientObjectMapperCustomizer` interface instead so this mechanism should be used moving forward.
 
 == Installation
 


### PR DESCRIPTION
- docs: add link to blog series
- docs: move bundle generation out of preview
- docs: deprecate QOSDK's ObjectMapper customization mechanism
