### PR TITLE
Add namespace configuration for generated manifests

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeOperatorConfiguration.java
@@ -24,6 +24,12 @@ public class BuildTimeOperatorConfiguration {
     public CRDConfiguration crd;
 
     /**
+     * The optional manifest-related configuration options
+     */
+    @ConfigItem
+    public ManifestConfiguration manifest;
+
+    /**
      * Whether controllers should only process events if the associated resource generation has
      * increased since last reconciliation, otherwise will process all events. Sets the default value
      * for all controllers.

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ManifestConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ManifestConfiguration.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.operatorsdk.runtime;
+
+import java.util.List;
+import java.util.Optional;
+
+import io.quarkus.runtime.annotations.ConfigGroup;
+import io.quarkus.runtime.annotations.ConfigItem;
+
+@ConfigGroup
+public class ManifestConfiguration {
+
+    /**
+     * The namespaces that the generated manifests should watch.
+     */
+    @ConfigItem
+    public Optional<List<String>> generateWithWatchedNamespaces;
+
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
@@ -122,6 +122,22 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-operator-sdk_quarkus.operator-sdk.manifest.generate-with-watched-namespaces]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.manifest.generate-with-watched-namespaces[quarkus.operator-sdk.manifest.generate-with-watched-namespaces]`
+
+[.description]
+--
+The namespaces that the generated manifests should watch
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPERATOR_SDK_MANIFEST_GENERATE_WITH_WATCHED_NAMESPACES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPERATOR_SDK_MANIFEST_GENERATE_WITH_WATCHED_NAMESPACES+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-operator-sdk_quarkus.operator-sdk.generation-aware]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.generation-aware[quarkus.operator-sdk.generation-aware]`
 
 [.description]


### PR DESCRIPTION
This enables the manifests generated at build time to be customised with namespaces to watch without affecting the controllers themselves. This way the controllers can use default behaviour allowing them to be configured at runtime, and the manifests can be used to apply that configuration at runtime.

Unfortunately, the logic to test for all namespaces and current namespaces in the Java operator SDK is in protected static methods, so I had to copy that logic into this project. It may be sensible to suggest that logic is made public in the Java operator SDK instead.

This came out of work being done for the keycloak oeprator here: https://github.com/keycloak/keycloak/pull/21231