### PR TITLE
fix: runtime namespaces should always override buildtime values

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/BuildTimeHybridControllerConfiguration.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/BuildTimeHybridControllerConfiguration.java
@@ -1,11 +1,5 @@
 package io.quarkiverse.operatorsdk.deployment;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 
@@ -34,23 +28,5 @@ class BuildTimeHybridControllerConfiguration {
                 "generationAwareEventProcessing",
                 AnnotationValue::asBoolean,
                 () -> operatorConfiguration.generationAware.orElse(true));
-    }
-
-    Set<String> namespaces() {
-        HashSet<String> namespaces = null;
-        if (controllerAnnotation != null) {
-            namespaces = Optional.ofNullable(controllerAnnotation.value("namespaces"))
-                    .map(v -> new HashSet<>(Arrays.asList(v.asStringArray())))
-                    .orElse(null);
-        }
-
-        if (externalConfiguration != null) {
-            Optional<List<String>> overrideNamespaces = externalConfiguration.generateWithWatchedNamespaces;
-            if (overrideNamespaces.isPresent()) {
-                namespaces = new HashSet<>(overrideNamespaces.get());
-            }
-        }
-
-        return namespaces;
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeControllerConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/BuildTimeControllerConfiguration.java
@@ -13,7 +13,7 @@ public class BuildTimeControllerConfiguration {
      * Whether the controller should only process events if the associated resource generation has
      * increased since last reconciliation, otherwise will process all events.
      */
-    @ConfigItem(defaultValue = "true")
+    @ConfigItem
     public Optional<Boolean> generationAware;
 
     /**

--- a/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
@@ -352,7 +352,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPERATOR_SDK_CONTROLLERS__CONTROLLERS__GENERATION_AWARE+++`
 endif::add-copy-button-to-env-var[]
 --|boolean 
-|`true`
+|
 
 
 a|icon:lock[title=Fixed at build time] [[quarkus-operator-sdk_quarkus.operator-sdk.controllers.-controllers-.generate-with-watched-namespaces]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.controllers.-controllers-.generate-with-watched-namespaces[quarkus.operator-sdk.controllers."controllers".generate-with-watched-namespaces]`

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,6 +1,8 @@
 quarkus.operator-sdk.namespaces=operator-level
 quarkus.operator-sdk.generation-aware=false
 quarkus.operator-sdk.controllers.test.retry.max-attempts=1
+# generating manifests with specific namespaces shouldn't preclude using operator-level namespaces at runtime
+quarkus.operator-sdk.controllers.test.generate-with-watched-namespaces=builtime-namespace1, buildtime-ns2
 quarkus.operator-sdk.controllers.annotation.finalizer=from-property/finalizer
 quarkus.operator-sdk.controllers.annotation.namespaces=bar
 quarkus.operator-sdk.controllers.annotation.retry.max-attempts=10


### PR DESCRIPTION
The previous behavior precluded operator-level defaulting at runtime
because setting the `generate-with-watched-namespaces` property was
marking the controller as having explicitly set namespaces. We now only
set that status if and only if namespaces were set using annotations.

Fixes #653
