### PR TITLE
Treat empty runtime namespaces as All Namespaces mode

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/Constants.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/Constants.java
@@ -1,0 +1,14 @@
+package io.quarkiverse.operatorsdk.runtime;
+
+import java.util.Collections;
+import java.util.Set;
+
+public final class Constants {
+    private Constants() {
+    }
+
+    public static final Set<String> QOSDK_USE_BUILDTIME_NAMESPACES_SET = Collections
+            .singleton(Constants.QOSDK_USE_BUILDTIME_NAMESPACES);
+
+    public static final String QOSDK_USE_BUILDTIME_NAMESPACES = "QOSDK_USE_BUILDTIME_NAMESPACES";
+}

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/RunTimeOperatorConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/RunTimeOperatorConfiguration.java
@@ -14,6 +14,8 @@
  */
 package io.quarkiverse.operatorsdk.runtime;
 
+import static io.quarkiverse.operatorsdk.runtime.Constants.QOSDK_USE_BUILDTIME_NAMESPACES;
+
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +61,10 @@ public class RunTimeOperatorConfiguration {
      * specified by the kube config file the operator uses.
      * </p>
      */
-    @ConfigItem
+    // We use a default here so that we are able to detect if the configuration value is set to "". Setting the value to "" will
+    // reset the configuration and result in an empty Optional, but not setting the value at all will result in the default being
+    // applied.
+    @ConfigItem(defaultValue = QOSDK_USE_BUILDTIME_NAMESPACES)
     public Optional<List<String>> namespaces;
 
     /**

--- a/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
@@ -303,7 +303,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPERATOR_SDK_NAMESPACES+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
-|
+|`QOSDK_USE_BUILDTIME_NAMESPACES`
 
 
 a| [[quarkus-operator-sdk_quarkus.operator-sdk.concurrent-workflow-threads]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.concurrent-workflow-threads[quarkus.operator-sdk.concurrent-workflow-threads]`


### PR DESCRIPTION
This makes the empty string in the namespaces configuration watch all namespaces, as per the documented behaviour: https://github.com/quarkiverse/quarkus-operator-sdk/blob/main/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/RunTimeOperatorConfiguration.java#L56

Fixes #656