### PR TITLE
feat: allow for exclusion of some classes when generating CRDs

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGeneration.java
@@ -149,6 +149,14 @@ class CRDGeneration {
 
     @SuppressWarnings("rawtypes")
     public void withCustomResource(Class<? extends CustomResource> crClass, String crdName, String associatedControllerName) {
+        // first check if the CR is not filtered out
+        if (crdConfiguration.excludeResources.map(excluded -> excluded.contains(crClass.getName())).orElse(false)) {
+            log.infov(
+                    "CRD generation was skipped for ''{1}'' because it was excluded from generation",
+                    crClass.getName());
+            return;
+        }
+
         try {
             // generator MUST be initialized before we start processing classes as initializing it
             // will reset the types information held by the generator

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationBuildStep.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/CRDGenerationBuildStep.java
@@ -19,13 +19,14 @@ import io.quarkus.deployment.builditem.LaunchModeBuildItem;
 import io.quarkus.deployment.builditem.LiveReloadBuildItem;
 import io.quarkus.deployment.pkg.builditem.OutputTargetBuildItem;
 
-public class CRDGenerationBuildStep {
+class CRDGenerationBuildStep {
     static final Logger log = Logger.getLogger(CRDGenerationBuildStep.class.getName());
+
+    private BuildTimeOperatorConfiguration buildTimeConfiguration;
 
     @BuildStep
     GeneratedCRDInfoBuildItem generateCRDs(
             ReconcilerInfosBuildItem reconcilers,
-            BuildTimeOperatorConfiguration buildTimeConfiguration,
             LaunchModeBuildItem launchModeBuildItem,
             LiveReloadBuildItem liveReload,
             OutputTargetBuildItem outputTarget,

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/AllCRDGenerationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/AllCRDGenerationTest.java
@@ -13,27 +13,28 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class NoCRDGenerationTest {
+public class AllCRDGenerationTest {
 
     // Start unit test with your extension loaded
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
             .setApplicationName("test")
             .withApplicationRoot(
-                    (jar) -> jar.addClasses(SimpleReconciler.class, SimpleCR.class, SimpleSpec.class, SimpleStatus.class))
-            .overrideConfigKey("quarkus.operator-sdk.crd.generate", "false");
+                    (jar) -> jar.addClasses(SimpleReconciler.class, SimpleCR.class, SimpleSpec.class, SimpleStatus.class,
+                            External.class))
+            .overrideConfigKey("quarkus.operator-sdk.crd.generate-all", "true");
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
 
     @Test
-    public void shouldNotGenerateCRDs() throws IOException {
+    public void shouldGenerateAllCRDs() throws IOException {
         final var kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
         final var kubeManifest = kubernetesDir.resolve("kubernetes.yml");
         Assertions.assertTrue(Files.exists(kubeManifest));
 
-        // checks that CRDs are NOT generated
-        Assertions.assertFalse(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(TestCR.class) + "-v1.yml")));
-        Assertions.assertFalse(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(SimpleCR.class) + "-v1.yml")));
+        // checks that CRDs are all generated
+        Assertions.assertTrue(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(SimpleCR.class) + "-v1.yml")));
+        Assertions.assertTrue(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(External.class) + "-v1.yml")));
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/ExcludedCRDGenerationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/ExcludedCRDGenerationTest.java
@@ -13,27 +13,29 @@ import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
 
-public class NoCRDGenerationTest {
+public class ExcludedCRDGenerationTest {
 
     // Start unit test with your extension loaded
     @RegisterExtension
     static final QuarkusProdModeTest config = new QuarkusProdModeTest()
             .setApplicationName("test")
             .withApplicationRoot(
-                    (jar) -> jar.addClasses(SimpleReconciler.class, SimpleCR.class, SimpleSpec.class, SimpleStatus.class))
-            .overrideConfigKey("quarkus.operator-sdk.crd.generate", "false");
+                    (jar) -> jar.addClasses(SimpleReconciler.class, SimpleCR.class, SimpleSpec.class, SimpleStatus.class,
+                            External.class))
+            .overrideConfigKey("quarkus.operator-sdk.crd.generate-all", "true")
+            .overrideConfigKey("quarkus.operator-sdk.crd.exclude-resources", SimpleCR.class.getName());
 
     @ProdBuildResults
     private ProdModeTestResults prodModeTestResults;
 
     @Test
-    public void shouldNotGenerateCRDs() throws IOException {
+    public void shouldOnlyGenerateNonExcludedCRDs() throws IOException {
         final var kubernetesDir = prodModeTestResults.getBuildDir().resolve("kubernetes");
         final var kubeManifest = kubernetesDir.resolve("kubernetes.yml");
         Assertions.assertTrue(Files.exists(kubeManifest));
 
-        // checks that CRDs are NOT generated
-        Assertions.assertFalse(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(TestCR.class) + "-v1.yml")));
+        // checks that only External CRD is generated
         Assertions.assertFalse(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(SimpleCR.class) + "-v1.yml")));
+        Assertions.assertTrue(Files.exists(kubernetesDir.resolve(CustomResource.getCRDName(External.class) + "-v1.yml")));
     }
 }

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/External.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/External.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.operatorsdk.test.sources;
+
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("halkyon.io")
+@Version("v1alpha1")
+public class External extends CustomResource<Void, Void> {
+
+    public static final String DISPLAY_NAME = "External display name";
+    public static final String DESCRIPTION = "External description";
+}

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/CRDConfiguration.java
@@ -61,4 +61,10 @@ public class CRDConfiguration {
     @ConfigItem(defaultValue = "false")
     public Boolean generateInParallel;
 
+    /**
+     * A comma-separated list of fully-qualified class names implementing custom resources to exclude from the CRD generation
+     * process.
+     */
+    @ConfigItem
+    public Optional<List<String>> excludeResources;
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
@@ -129,6 +129,23 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a|icon:lock[title=Fixed at build time] [[quarkus-operator-sdk_quarkus.operator-sdk.crd.exclude-resources]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.crd.exclude-resources[quarkus.operator-sdk.crd.exclude-resources]`
+
+
+[.description]
+--
+A comma-separated list of fully-qualified class names implementing custom resources to exclude from the CRD generation process.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OPERATOR_SDK_CRD_EXCLUDE_RESOURCES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OPERATOR_SDK_CRD_EXCLUDE_RESOURCES+++`
+endif::add-copy-button-to-env-var[]
+--|list of string 
+|
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-operator-sdk_quarkus.operator-sdk.generation-aware]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.generation-aware[quarkus.operator-sdk.generation-aware]`
 
 


### PR DESCRIPTION
A new configuration property quarkus.operator-sdk.crd.exclude-resources
has been introduced to provide fully-qualified class names of resource
classes to be excluded from CRD generation.
Fixes #674
