### PR TITLE
fix: bundle generation configuration shouldn't be available at runtime

### DIFF
--- a/bundle-generator/runtime/src/main/java/io/quarkiverse/operatorsdk/bundle/runtime/BundleGenerationConfiguration.java
+++ b/bundle-generator/runtime/src/main/java/io/quarkiverse/operatorsdk/bundle/runtime/BundleGenerationConfiguration.java
@@ -4,10 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import io.quarkus.runtime.annotations.ConfigItem;
-import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 
-@ConfigRoot(name = "operator-sdk.bundle", phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(name = "operator-sdk.bundle")
 public class BundleGenerationConfiguration {
     /**
      * Whether the extension should generate the Operator bundle.


### PR DESCRIPTION
Fixes #689
