### PR TITLE
fix: runtime namespaces are now correctly set from controller properties 

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/RunTimeControllerConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/RunTimeControllerConfiguration.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.operatorsdk.runtime;
 
+import static io.quarkiverse.operatorsdk.runtime.Constants.QOSDK_USE_BUILDTIME_NAMESPACES;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -15,7 +17,7 @@ public class RunTimeControllerConfiguration {
      * The value can be set to "JOSDK_WATCH_CURRENT" to watch the current (default) namespace from kube config.
      * Constant(s) can be found in at {@link io.javaoperatorsdk.operator.api.reconciler.Constants}".
      */
-    @ConfigItem
+    @ConfigItem(defaultValue = QOSDK_USE_BUILDTIME_NAMESPACES)
     public Optional<List<String>> namespaces;
 
     /**

--- a/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-operator-sdk.adoc
@@ -483,7 +483,7 @@ ifndef::add-copy-button-to-env-var[]
 Environment variable: `+++QUARKUS_OPERATOR_SDK_CONTROLLERS__CONTROLLERS__NAMESPACES+++`
 endif::add-copy-button-to-env-var[]
 --|list of string 
-|
+|`QOSDK_USE_BUILDTIME_NAMESPACES`
 
 
 a| [[quarkus-operator-sdk_quarkus.operator-sdk.controllers.-controllers-.finalizer]]`link:#quarkus-operator-sdk_quarkus.operator-sdk.controllers.-controllers-.finalizer[quarkus.operator-sdk.controllers."controllers".finalizer]`


### PR DESCRIPTION
Fixes #725

@metacosm  If there are soem tests which I can draw inspiration from, let me know and I will add some coverage. Otherwise I will be leaving this up to you as understanding how exactly I should write the tests is something I don't have the time for right now.