### PR TITLE
Fix bundle-generator/deployment manifest generation in integration tests

### DIFF
--- a/bundle-generator/deployment/pom.xml
+++ b/bundle-generator/deployment/pom.xml
@@ -57,6 +57,14 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <configuration>
+                <!-- set tmpdir as early as possible because surefire sets it too late for JDK16 -->
+                <argLine>-Djava.io.tmpdir="${project.build.directory}"</argLine>
+              </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.operatorsdk.bundle;
 
 import static io.quarkiverse.operatorsdk.bundle.Utils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.quarkiverse.operatorsdk.bundle.sources.*;
+import io.quarkiverse.operatorsdk.common.ConfigurationUtils;
 import io.quarkus.test.ProdBuildResults;
 import io.quarkus.test.ProdModeTestResults;
 import io.quarkus.test.QuarkusProdModeTest;
@@ -81,14 +83,13 @@ public class MultipleOperatorsBundleTest {
         assertEquals(VERSION, spec.getVersion());
 
         // check that the env variable to set the reconciler namespaces is properly set
-        /*
-         * disabled because of https://github.com/quarkusio/quarkus/issues/36041
-         * final var firstContainer = spec.getInstall().getSpec().getDeployments().get(0).getSpec().getTemplate().getSpec()
-         * .getContainers().get(0);
-         * assertTrue(firstContainer.getEnv().stream()
-         * .anyMatch(envVar -> envVar.getName()
-         * .equals(ConfigurationUtils.getNamespacesPropertyName(ThirdReconciler.NAME, true))));
-         *
-         */
+
+        //disabled because of https://github.com/quarkusio/quarkus/issues/36041
+        final var firstContainer = spec.getInstall().getSpec().getDeployments().get(0).getSpec().getTemplate().getSpec()
+                .getContainers().get(0);
+        assertTrue(firstContainer.getEnv().stream()
+                .anyMatch(envVar -> envVar.getName()
+                        .equals(ConfigurationUtils.getNamespacesPropertyName(ThirdReconciler.NAME, true))));
+
     }
 }


### PR DESCRIPTION
This pull request addresses: https://github.com/quarkusio/quarkus/issues/36041

So, what's the issue?

dekorate and by extension quarkus-kubernetes need to run from within an actual project (gradle, maven etc). 
This is not the case in prod mode tests as the contain no sources and no build files.

In quarkus we workaround the issue by generating temp directories under an actual project dir.
Let's do the same here.