### PR TITLE
refactor: do related steps in succession instead of by "type"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,26 @@ jobs:
           mvn -B versions:set-property -Dproperty=quarkus-operator-sdk.version -DnewVersion=${{steps.metadata.outputs.current-version}}
           ./mvnw -Dsync
 
+      - name: Create quarkus-platform pull request
+        uses: peter-evans/create-pull-request@v5
+        id: qp-pr
+        with:
+          path: quarkus-platform
+          title: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
+          commit-message: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
+          committer: metacosm <metacosm@users.noreply.github.com>
+          author: metacosm <metacosm@users.noreply.github.com>
+          branch: qosdk-release-${{steps.metadata.outputs.current-version}}
+          token: ${{ secrets.QOSDK_BOT_TOKEN }}
+          push-to-fork: qosdk-bot/quarkus-platform
+          delete-branch: true
+
+      - name: Check quarkus-platform PR
+        if: ${{ steps.qp-pr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"
+
       - uses: actions/checkout@v3
         with:
           repository: operator-framework/java-operator-plugins
@@ -98,23 +118,3 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.jop-pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.jop-pr.outputs.pull-request-url }}"
-
-      - name: Create quarkus-platform pull request
-        uses: peter-evans/create-pull-request@v5
-        id: qp-pr
-        with:
-          path: quarkus-platform
-          title: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
-          commit-message: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
-          committer: metacosm <metacosm@users.noreply.github.com>
-          author: metacosm <metacosm@users.noreply.github.com>
-          branch: qosdk-release-${{steps.metadata.outputs.current-version}}
-          token: ${{ secrets.QOSDK_BOT_TOKEN }}
-          push-to-fork: qosdk-bot/quarkus-platform
-          delete-branch: true
-
-      - name: Check quarkus-platform PR
-        if: ${{ steps.qp-pr.outputs.pull-request-number }}
-        run: |
-          echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"


### PR DESCRIPTION
More concretely do everything pertaining to quarkus-platform (including
PR creation) before starting the update of OSDK plugins PR process. This
way, if one step fails, the other one can still go through, since they
are independent.

[skip ci]

Signed-off-by: Chris Laprun <claprun@redhat.com>
