### PR TITLE
fix: adapt release process for 6.3.x maintenance branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: quarkusio/quarkus-platform
+          ref: 3.2
           path: quarkus-platform
 
       - name: Update QOSDK version to ${{steps.metadata.outputs.current-version}} in quarkus-platform

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,34 +88,3 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"
-
-      - uses: actions/checkout@v3
-        with:
-          repository: operator-framework/java-operator-plugins
-          path: sdk-plugins
-
-      - name: Update QOSDK version to ${{steps.metadata.outputs.current-version}} in java-operator-plugins
-        run: |
-          cd sdk-plugins
-          sed -i -e 's|<quarkus-sdk.version>.*</quarkus-sdk.version>|<quarkus-sdk.version>${{steps.metadata.outputs.current-version}}</quarkus-sdk.version>|' $(pwd)/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
-          sed -i -e 's|<quarkus-sdk.version>.*</quarkus-sdk.version>|<quarkus-sdk.version>${{steps.metadata.outputs.current-version}}</quarkus-sdk.version>|' $(pwd)/testdata/quarkus/memcached-quarkus-operator/pom.xml
-
-      - name: Create java-operator-plugins pull request
-        uses: peter-evans/create-pull-request@v5
-        id: jop-pr
-        with:
-          path: sdk-plugins
-          title: "feat: update QOSDK to ${{steps.metadata.outputs.current-version}}"
-          commit-message: "feat: update QOSDK to ${{steps.metadata.outputs.current-version}}"
-          committer: metacosm <metacosm@users.noreply.github.com>
-          author: metacosm <metacosm@users.noreply.github.com>
-          branch: qosdk-release-${{steps.metadata.outputs.current-version}}
-          token: ${{ secrets.QOSDK_BOT_TOKEN }}
-          push-to-fork: qosdk-bot/java-operator-plugins
-          delete-branch: true
-
-      - name: Check java-operator-plugins PR
-        if: ${{ steps.jop-pr.outputs.pull-request-number }}
-        run: |
-          echo "Pull Request Number - ${{ steps.jop-pr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.jop-pr.outputs.pull-request-url }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,26 @@ jobs:
           mvn -B versions:set-property -Dproperty=quarkus-operator-sdk.version -DnewVersion=${{steps.metadata.outputs.current-version}}
           ./mvnw -Dsync
 
+      - name: Create quarkus-platform pull request
+        uses: peter-evans/create-pull-request@v5
+        id: qp-pr
+        with:
+          path: quarkus-platform
+          title: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
+          commit-message: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
+          committer: metacosm <metacosm@users.noreply.github.com>
+          author: metacosm <metacosm@users.noreply.github.com>
+          branch: qosdk-release-${{steps.metadata.outputs.current-version}}
+          token: ${{ secrets.QOSDK_BOT_TOKEN }}
+          push-to-fork: qosdk-bot/quarkus-platform
+          delete-branch: true
+
+      - name: Check quarkus-platform PR
+        if: ${{ steps.qp-pr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"
+
       - uses: actions/checkout@v3
         with:
           repository: operator-framework/java-operator-plugins
@@ -98,23 +118,3 @@ jobs:
         run: |
           echo "Pull Request Number - ${{ steps.jop-pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.jop-pr.outputs.pull-request-url }}"
-
-      - name: Create quarkus-platform pull request
-        uses: peter-evans/create-pull-request@v5
-        id: qp-pr
-        with:
-          path: quarkus-platform
-          title: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
-          commit-message: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
-          committer: metacosm <metacosm@users.noreply.github.com>
-          author: metacosm <metacosm@users.noreply.github.com>
-          branch: qosdk-release-${{steps.metadata.outputs.current-version}}
-          token: ${{ secrets.QOSDK_BOT_TOKEN }}
-          push-to-fork: qosdk-bot/quarkus-platform
-          delete-branch: true
-
-      - name: Check quarkus-platform PR
-        if: ${{ steps.qp-pr.outputs.pull-request-number }}
-        run: |
-          echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
-          echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"


### PR DESCRIPTION
- refactor: do related steps in succession instead of by "type"
- fix: checkout 3.2 branch of platform project
- fix: do not update OSDK plugin when releasing 6.3
