### PR TITLE
fix: enable resource filtering

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Java Operator SDK Extension
 release:
-  current-version: 6.4.0.Beta1
+  current-version: 6.4.0.Beta2
   next-version: 6.4.0-SNAPSHOT
 

--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Java Operator SDK Extension
 release:
-  current-version: 6.4.0.Beta2
-  next-version: 6.4.0-SNAPSHOT
+  current-version: 6.4.0
+  next-version: 6.4.1-SNAPSHOT
 

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -63,6 +63,12 @@
     </dependency>
   </dependencies>
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>io.quarkus</groupId>

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 6.4.0.Beta2
+:project-version: 6.4.0
 
 :examples-dir: ./../examples/

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 6.4.0.Beta1
+:project-version: 6.4.0.Beta2
 
 :examples-dir: ./../examples/


### PR DESCRIPTION
This is needed so that the cli-plugins field in quarkus-extension.yml is
properly populated.

Signed-off-by: Chris Laprun <claprun@redhat.com>
