### PR TITLE
feat: fail build if using deprecated CSV features

### DIFF
--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/FailOnDeprecatedAnnotationsTest.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/FailOnDeprecatedAnnotationsTest.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.operatorsdk.bundle;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadata;
+import io.quarkiverse.operatorsdk.bundle.runtime.SharedCSVMetadata;
+import io.quarkiverse.operatorsdk.bundle.sources.*;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class FailOnDeprecatedAnnotationsTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setApplicationName("deprecated-annotations")
+            .assertBuildException(e -> {
+                // exception should be a runtime exception wrapping a build exception wrapping our own exception
+                assertInstanceOf(IllegalStateException.class, e.getCause().getCause());
+                final var message = e.getMessage();
+                assertTrue(message.contains(DeprecatedReconciler.class.getName()));
+                assertTrue(message.contains(CSVMetadata.class.getName()));
+                assertTrue(message.contains(SharedCSVMetadata.class.getName()));
+            })
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(DeprecatedReconciler.class));
+
+    @Test
+    public void shouldFailWhenUsingDeprecatedMetadataAnnotations() {
+        fail("Should have failed!");
+    }
+
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/DeprecatedReconciler.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/DeprecatedReconciler.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+import io.quarkiverse.operatorsdk.bundle.runtime.CSVMetadata;
+import io.quarkiverse.operatorsdk.bundle.runtime.SharedCSVMetadata;
+
+@CSVMetadata(name = "deprecated")
+public class DeprecatedReconciler implements Reconciler<ConfigMap>, SharedCSVMetadata {
+    @Override
+    public UpdateControl<ConfigMap> reconcile(ConfigMap configMap, Context<ConfigMap> context) throws Exception {
+        return null;
+    }
+}


### PR DESCRIPTION
Supporting both deprecated and replacement versions is too complex for
a corner use case to support, so we now fail the build when users are
still using the deprecated version to inform them instead of failing
silently.

Fixes #770

Signed-off-by: Chris Laprun <claprun@redhat.com>
