### PR TITLE
fix: do not start operator, as only configuration is needed

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/DefaultConfigurationTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/DefaultConfigurationTest.java
@@ -16,6 +16,7 @@ public class DefaultConfigurationTest {
 
     @RegisterExtension
     static QuarkusUnitTest runner = new QuarkusUnitTest()
+            .overrideConfigKey("quarkus.operator-sdk.start-operator", "false")
             .withApplicationRoot(
                     jar -> jar.addClasses(SimpleReconciler.class, SimpleCR.class, SimpleStatus.class, SimpleSpec.class));
 


### PR DESCRIPTION
Signed-off-by: Chris Laprun <claprun@redhat.com>
