### PR TITLE
feat: log if shutdown was standard or not

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/AppEventListener.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/AppEventListener.java
@@ -36,7 +36,8 @@ public class AppEventListener {
 
     public void onShutdown(@Observes ShutdownEvent event) {
         if (configurationService.shouldStartOperator()) {
-            log.info("Quarkus Java Operator SDK extension is shutting down.");
+            log.info("Quarkus Java Operator SDK extension is shutting down. Is standard shutdown: {}",
+                    event.isStandardShutdown());
             operator.stop();
         } else {
             log.warn("Operator was configured not to start automatically, call the stop method to stop it.");


### PR DESCRIPTION
During troublesheeting an issue the QOSDK was shutting down unexpectedly, this will give more information if it comes from OS or the app exists.