### PR TITLE
chore(ci): open quarkus-platform PRs on appropriate branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,101 @@
+name: Testing workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      current-version:
+        description: 'QOSDK version'
+        type: string
+        required: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        
+      - name: Process ${{inputs.current-version}}
+        id: release-qosdk
+        run: |
+          quarkus_major=$(mvn help:evaluate -Dexpression=quarkus.version -q -DforceStdout | cut -d . -f 1,2)
+           echo "QOSDK defined Quarkus major version: ${quarkus_major}"
+          quarkus_platform_version=$(curl -s https://registry.quarkus.io/client/platforms | jq -r '.platforms[0]."current-stream-id"')
+          echo "Current platform-defined Quarkus major version: ${quarkus_platform_version}"
+          quarkus_platform_branch=main
+          if [ "${{steps.release-qosdk.outputs.quarkus_major}}" = "${quarkus_platform_version}"]; then
+            quarkus_platform_branch="${quarkus_platform_version}"
+          fi
+          echo "quarkus_platform_branch=${quarkus_platform_branch}" >> $GITHUB_OUTPUT
+          
+      - uses: actions/checkout@v3
+        with:
+          repository: quarkusio/quarkus-platform
+          path: quarkus-platform
+
+      - name: Update QOSDK version to ${{inputs.current-version}} in quarkus-platform ${{steps.release-qosdk.outputs.quarkus_platform_branch}}
+        run: |
+          cd quarkus-platform
+          git checkout ${{steps.release-qosdk.outputs.quarkus_platform_branch}}
+          mvn -B versions:set-property -Dproperty=quarkus-operator-sdk.version -DnewVersion=${{inputs.current-version}}
+          ./mvnw -Dsync
+
+      - name: Create quarkus-platform pull request
+        uses: peter-evans/create-pull-request@v5
+        id: qp-pr
+        with:
+          path: quarkus-platform
+          title: "Update QOSDK to ${{inputs.current-version}} for ${{steps.release-qosdk.outputs.quarkus_platform_branch}}"
+          commit-message: "Update QOSDK to ${{inputs.current-version}}"
+          committer: metacosm <metacosm@users.noreply.github.com>
+          author: metacosm <metacosm@users.noreply.github.com>
+          branch: qosdk-release-${{inputs.current-version}}-${{steps.release-qosdk.outputs.quarkus_platform_branch}}
+          token: ${{ secrets.QOSDK_BOT_TOKEN }}
+          push-to-fork: qosdk-bot/quarkus-platform
+          delete-branch: true
+
+      - name: Check quarkus-platform PR
+        if: ${{ steps.qp-pr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"
+
+      - name: Check if Quarkus Platform PR also needs to be opened on main
+        if: "${{ steps.release-qosdk.outputs.quarkus_platform_branch != 'main' }}"
+        id: need-main-pr-check
+        run: |
+          qosdk_latest=$(curl -sL https://api.github.com/repos/quarkiverse/quarkus-operator-sdk/releases/latest | jq -r ".tag_name")
+          echo "Latest QOSDK release: ${qosdk_latest}"
+          if [ "${{inputs.current-version}}" = "${qosdk_latest}" ]; then
+            echo "need_main_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "No need for PR on quarkus-platform main"
+          fi
+
+      - name: Update QOSDK version to ${{inputs.current-version}} in quarkus-platform main
+        if: "${{steps.need-main-pr-check.outputs.need_main_pr == 'true'}}"
+        run: |
+          cd quarkus-platform
+          git reset --hard origin/main
+          mvn -B versions:set-property -Dproperty=quarkus-operator-sdk.version -DnewVersion=${{inputs.current-version}}
+          ./mvnw -Dsync
+
+      - name: Create quarkus-platform pull request
+        if: "${{steps.need-main-pr-check.outputs.need_main_pr == 'true'}}"
+        uses: peter-evans/create-pull-request@v5
+        id: qp-pr-main
+        with:
+          path: quarkus-platform
+          title: "Update QOSDK to ${{inputs.current-version}}"
+          commit-message: "Update QOSDK to ${{inputs.current-version}}"
+          committer: metacosm <metacosm@users.noreply.github.com>
+          author: metacosm <metacosm@users.noreply.github.com>
+          branch: qosdk-release-${{inputs.current-version}}
+          token: ${{ secrets.QOSDK_BOT_TOKEN }}
+          push-to-fork: qosdk-bot/quarkus-platform
+          delete-branch: true
+
+      - name: Check main quarkus-platform PR
+        if: ${{ steps.qp-pr-main.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,17 @@ jobs:
           git config --local user.name "GitHub Action"
 
       - name: Maven release ${{steps.metadata.outputs.current-version}}
+        id: release-qosdk
         run: |
+          quarkus_major=$(mvn help:evaluate -Dexpression=quarkus.version -q -DforceStdout | cut -d . -f 1,2)
+           echo "QOSDK defined Quarkus major version: ${quarkus_major}"
+          quarkus_platform_version=$(curl -s https://registry.quarkus.io/client/platforms | jq -r '.platforms[0]."current-stream-id"')
+          echo "Current platform-defined Quarkus major version: ${quarkus_platform_version}"
+          quarkus_platform_branch=main
+          if [ "${{steps.release-qosdk.outputs.quarkus_major}}" = "${quarkus_platform_version}"]; then
+            quarkus_platform_branch="${quarkus_platform_version}"
+          fi
+          echo "quarkus_platform_branch=${quarkus_platform_branch}" >> $GITHUB_OUTPUT
           git checkout -b release
           mvn -B release:prepare -Prelease -Darguments="-DperformRelease -Dno-samples -DskipTests" -DreleaseVersion=${{steps.metadata.outputs.current-version}} -DdevelopmentVersion=${{steps.metadata.outputs.next-version}}
           git checkout ${{github.base_ref}}
@@ -66,15 +76,57 @@ jobs:
           repository: quarkusio/quarkus-platform
           path: quarkus-platform
 
-      - name: Update QOSDK version to ${{steps.metadata.outputs.current-version}} in quarkus-platform
+      - name: Update QOSDK version to ${{steps.metadata.outputs.current-version}} in quarkus-platform ${{steps.release-qosdk.outputs.quarkus_platform_branch}}
         run: |
           cd quarkus-platform
+          git checkout ${{steps.release-qosdk.outputs.quarkus_platform_branch}}
           mvn -B versions:set-property -Dproperty=quarkus-operator-sdk.version -DnewVersion=${{steps.metadata.outputs.current-version}}
           ./mvnw -Dsync
 
       - name: Create quarkus-platform pull request
         uses: peter-evans/create-pull-request@v5
         id: qp-pr
+        with:
+          path: quarkus-platform
+          title: "Update QOSDK to ${{steps.metadata.outputs.current-version}} for ${{steps.release-qosdk.outputs.quarkus_platform_branch}}"
+          commit-message: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
+          committer: metacosm <metacosm@users.noreply.github.com>
+          author: metacosm <metacosm@users.noreply.github.com>
+          branch: qosdk-release-${{steps.metadata.outputs.current-version}}-${{steps.release-qosdk.outputs.quarkus_platform_branch}}
+          token: ${{ secrets.QOSDK_BOT_TOKEN }}
+          push-to-fork: qosdk-bot/quarkus-platform
+          delete-branch: true
+
+      - name: Check quarkus-platform PR
+        if: ${{ steps.qp-pr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"
+
+      - name: Check if Quarkus Platform PR also needs to be opened on main
+        if: "${{ steps.release-qosdk.outputs.quarkus_platform_branch != 'main' }}"
+        id: need-main-pr-check
+        run: |
+          qosdk_latest=$(curl -sL https://api.github.com/repos/quarkiverse/quarkus-operator-sdk/releases/latest | jq -r ".tag_name")
+          echo "Latest QOSDK release: ${qosdk_latest}"
+          if [ "${{steps.metadata.outputs.current-version}}" = "${qosdk_latest}" ]; then
+            echo "need_main_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "No need for PR on quarkus-platform main"
+          fi
+
+      - name: Update QOSDK version to ${{steps.metadata.outputs.current-version}} in quarkus-platform main
+        if: "${{steps.need-main-pr-check.outputs.need_main_pr == 'true'}}"
+        run: |
+          cd quarkus-platform
+          git reset --hard origin/main
+          mvn -B versions:set-property -Dproperty=quarkus-operator-sdk.version -DnewVersion=${{steps.metadata.outputs.current-version}}
+          ./mvnw -Dsync
+
+      - name: Create quarkus-platform pull request
+        if: "${{steps.need-main-pr-check.outputs.need_main_pr == 'true'}}"
+        uses: peter-evans/create-pull-request@v5
+        id: qp-pr-main
         with:
           path: quarkus-platform
           title: "Update QOSDK to ${{steps.metadata.outputs.current-version}}"
@@ -86,12 +138,12 @@ jobs:
           push-to-fork: qosdk-bot/quarkus-platform
           delete-branch: true
 
-      - name: Check quarkus-platform PR
-        if: ${{ steps.qp-pr.outputs.pull-request-number }}
+      - name: Check main quarkus-platform PR
+        if: ${{ steps.qp-pr-main.outputs.pull-request-number }}
         run: |
           echo "Pull Request Number - ${{ steps.qp-pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.qp-pr.outputs.pull-request-url }}"
-
+        
       - uses: actions/checkout@v3
         with:
           repository: operator-framework/java-operator-plugins


### PR DESCRIPTION
PR will also be opened on main if needed (i.e. if this is for the latest
QOSDK release).

Signed-off-by: Chris Laprun <claprun@redhat.com>
