### PR TITLE
fix: use Kubernetes configuration for name and version when available

### DIFF
--- a/annotations/src/main/java/io/quarkiverse/operatorsdk/annotations/CSVMetadata.java
+++ b/annotations/src/main/java/io/quarkiverse/operatorsdk/annotations/CSVMetadata.java
@@ -105,8 +105,11 @@ public @interface CSVMetadata {
         String[] verbs() default { "get", "list", "watch", "create", "delete", "patch", "update" };
 
         /**
-         * @return the service account name for the permission rule. If not provided, it will use the default service account
-         *         name.
+         * @return the service account name to which the permission rule will be assigned. If not provided, the default service
+         *         account name as defined for your operator will be used. Note that for the rule to be effectively added to the
+         *         CSV, a service account with that name <em>must</em> exist in the generated kubernetes manifests as this is
+         *         the base upon which the bundle generator works. This means that if you add a rule that targets a service
+         *         account that is not present in the generated manifest, then this rule won't appear in the generated CSV.
          */
         String serviceAccountName() default "";
     }

--- a/annotations/src/main/java/io/quarkiverse/operatorsdk/annotations/CSVMetadata.java
+++ b/annotations/src/main/java/io/quarkiverse/operatorsdk/annotations/CSVMetadata.java
@@ -91,6 +91,12 @@ public @interface CSVMetadata {
         boolean supported() default true;
     }
 
+    /**
+     * Additional RBAC rules that need to be provided because they cannot be inferred automatically. Note that RBAC rules added
+     * to your reconciler via {@link RBACRule} should already be handled automatically, under the service account name
+     * associated with your Reconciler so this annotation should only be used to add additional rules to other service accounts
+     * or for rules that you don't want to appear in the generated Kubernetes manifests.
+     */
     @interface PermissionRule {
         String[] apiGroups();
 

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/BundleProcessor.java
@@ -66,15 +66,17 @@ public class BundleProcessor {
 
     @SuppressWarnings({ "unused" })
     @BuildStep(onlyIf = IsGenerationEnabled.class)
-    CSVMetadataBuildItem gatherCSVMetadata(ApplicationInfoBuildItem configuration,
+    CSVMetadataBuildItem gatherCSVMetadata(KubernetesConfig kubernetesConfig,
+            ApplicationInfoBuildItem appConfiguration,
             BundleGenerationConfiguration bundleConfiguration,
             CombinedIndexBuildItem combinedIndexBuildItem) {
         final var index = combinedIndexBuildItem.getIndex();
-        final var defaultName = bundleConfiguration.packageName.orElse(configuration.getName());
+        final var defaultName = bundleConfiguration.packageName
+                .orElse(ResourceNameUtil.getResourceName(kubernetesConfig, appConfiguration));
 
         // note that version, replaces, etc. should probably be settable at the reconciler level
         // use version specified in bundle configuration, if not use the one extracted from the project, if available
-        final var version = configuration.getVersion();
+        final var version = kubernetesConfig.getVersion().orElse(appConfiguration.getVersion());
         final var defaultVersion = bundleConfiguration.version
                 .orElse(ApplicationInfoBuildItem.UNSET_VALUE.equals(version) ? null : version);
 

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/SecondReconciler.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/SecondReconciler.java
@@ -1,12 +1,19 @@
 package io.quarkiverse.operatorsdk.bundle.sources;
 
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
+import io.quarkiverse.operatorsdk.annotations.RBACRule;
 
 @CSVMetadata(name = "second-operator")
+@RBACRule(apiGroups = SecondReconciler.RBAC_RULE_GROUP, resources = SecondReconciler.RBAC_RULE_RES, verbs = SecondReconciler.RBAC_RULE_VERBS)
+@ControllerConfiguration(namespaces = "foo")
 public class SecondReconciler implements Reconciler<Second> {
+    public static final String RBAC_RULE_GROUP = "halkyon.io";
+    public static final String RBAC_RULE_RES = "SomeResource";
+    public static final String RBAC_RULE_VERBS = "write";
 
     @Override
     public UpdateControl<Second> reconcile(Second request, Context<Second> context) {

--- a/samples/joke/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconciler.java
+++ b/samples/joke/src/main/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconciler.java
@@ -30,11 +30,13 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.CSVMetadata.Icon;
+import io.quarkiverse.operatorsdk.annotations.RBACRule;
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestSpec.ExcludedTopic;
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestStatus.State;
 
-@CSVMetadata(permissionRules = @CSVMetadata.PermissionRule(apiGroups = Joke.GROUP, resources = "jokes"), requiredCRDs = @CSVMetadata.RequiredCRD(kind = "Joke", name = Joke.NAME, version = Joke.VERSION), icon = @Icon(fileName = "icon.png", mediatype = "image/png"))
+@CSVMetadata(requiredCRDs = @CSVMetadata.RequiredCRD(kind = "Joke", name = Joke.NAME, version = Joke.VERSION), icon = @Icon(fileName = "icon.png", mediatype = "image/png"))
 @ControllerConfiguration(namespaces = WATCH_CURRENT_NAMESPACE)
+@RBACRule(apiGroups = Joke.GROUP, resources = "jokes", verbs = RBACRule.ALL)
 @SuppressWarnings("unused")
 public class JokeRequestReconciler implements Reconciler<JokeRequest> {
     @Inject


### PR DESCRIPTION
- fix: use Kubernetes configuration for name and version when available
- refactor: RBACRule should be used instead of PermissionRule
