### PR TITLE
feat: move to Java 17 baseline, release 6.6.0

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Java Operator SDK Extension
 release:
-  current-version: 6.5.1
-  next-version: 6.5.2-SNAPSHOT
+  current-version: 6.6.0
+  next-version: 6.6.1-SNAPSHOT
 

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>quarkus-operator-sdk-annotations</artifactId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-parent</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk-bom</artifactId>
   <name>Quarkus - Operator SDK - BOM</name>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-parent</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk-build-parent</artifactId>
   <packaging>pom</packaging>

--- a/build-parent/pom.xml
+++ b/build-parent/pom.xml
@@ -11,8 +11,8 @@
   <name>Quarkus - Operator SDK - Build Parent</name>
   <properties>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/bundle-generator/deployment/pom.xml
+++ b/bundle-generator/deployment/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-bundle-generator-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
     </parent>
 
     <name>Quarkus - Operator SDK - Bundle Generator - Deployment</name>

--- a/bundle-generator/pom.xml
+++ b/bundle-generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/bundle-generator/runtime/pom.xml
+++ b/bundle-generator/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-bundle-generator-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
     </parent>
 
     <name>Quarkus - Operator SDK - Bundle Generator - Runtime</name>

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/common-deployment/pom.xml
+++ b/common-deployment/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-core-parent</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk-deployment</artifactId>
   <name>Quarkus - Operator SDK - Core - Deployment</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-core-parent</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-operator-sdk</artifactId>
   <name>Quarkus - Operator SDK - Core - Runtime</name>

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 6.5.1
+:project-version: 6.6.0
 
 :examples-dir: ./../examples/

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.quarkiverse.operatorsdk</groupId>
         <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-        <version>6.5.2-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../build-parent/pom.xml</relativePath>
     </parent>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-build-parent</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <artifactId>quarkus-operator-sdk-integration-tests</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <groupId>io.quarkiverse.operatorsdk</groupId>
   <artifactId>quarkus-operator-sdk-parent</artifactId>
-  <version>6.5.2-SNAPSHOT</version>
+  <version>6.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Quarkus - Operator SDK - Parent</name>
   <properties>

--- a/samples/exposedapp/pom.xml
+++ b/samples/exposedapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
     <groupId>io.quarkiverse.operatorsdk</groupId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/samples/joke/pom.xml
+++ b/samples/joke/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/samples/mysql-schema/pom.xml
+++ b/samples/mysql-schema/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>quarkus-operator-sdk-samples-mysql-schema</artifactId>

--- a/samples/pingpong/pom.xml
+++ b/samples/pingpong/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-samples</artifactId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>quarkus-operator-sdk-build-parent</artifactId>
     <groupId>io.quarkiverse.operatorsdk</groupId>
-    <version>6.5.2-SNAPSHOT</version>
+    <version>6.6.0-SNAPSHOT</version>
     <relativePath>../build-parent/pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
- chore: update version to 6.6.0-SNAPSHOT
- feat: move to Java 17 baseline
- chore: release 6.6.0
