### PR TITLE
fix: helm chart generates invalid YAML when watching all namespaces

### DIFF
--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/FileUtils.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/FileUtils.java
@@ -2,9 +2,7 @@ package io.quarkiverse.operatorsdk.common;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.util.List;
 
-import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.utils.KubernetesSerialization;
 
 public class FileUtils {
@@ -18,10 +16,18 @@ public class FileUtils {
         }
     }
 
-    public static List<HasMetadata> unmarshalFrom(byte[] yamlOrJson) {
+    /**
+     * Unmarshal the given YAML or JSON to an object. The returned object will be a list if the input
+     * is a YAML/JSON array.
+     */
+    public static Object unmarshalFrom(byte[] yamlOrJson) {
         return serializer.unmarshal(new ByteArrayInputStream(yamlOrJson));
     }
 
+    /**
+     * Serialize the given object to YAML. If the given object is a list, the returned YAML will be a
+     * YAML array.
+     */
     public static String asYaml(Object toSerialize) {
         return serializer.asYaml(toSerialize);
     }

--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/GeneratedResourcesUtils.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/GeneratedResourcesUtils.java
@@ -22,10 +22,15 @@ public class GeneratedResourcesUtils {
         var buildItem = generatedResources.stream()
                 .filter(r -> resourceName.equals(r.getName()))
                 .findAny();
-        return buildItem.map(bi -> FileUtils.unmarshalFrom(bi.getContent()))
-                .orElseThrow(() -> new IllegalArgumentException("Couldn't find resource " + resourceName +
-                        " in generated resources: " + generatedResources.stream()
-                                .map(GeneratedKubernetesResourceBuildItem::getName).collect(Collectors.toSet())));
+        @SuppressWarnings("unchecked")
+        List<HasMetadata> resources = (List<HasMetadata>) buildItem.map(
+                bi -> FileUtils.unmarshalFrom(bi.getContent()))
+                .orElseThrow(
+                        () -> new IllegalArgumentException("Couldn't find resource " + resourceName +
+                                " in generated resources: " + generatedResources.stream()
+                                        .map(GeneratedKubernetesResourceBuildItem::getName)
+                                        .collect(Collectors.toSet())));
+        return resources;
     }
 
     public static List<HasMetadata> loadFrom(List<GeneratedKubernetesResourceBuildItem> generatedResources) {

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/helm/HelmChartProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/helm/HelmChartProcessor.java
@@ -134,7 +134,8 @@ public class HelmChartProcessor {
         resources = filterOutStandardResources(resources, ResourceNameUtil.getResourceName(kubernetesConfig, appInfo));
         if (!resources.isEmpty()) {
             final var kubernetesManifest = helmDirBI.getPathToTemplatesDir().resolve("kubernetes.yml");
-            String yaml = FileUtils.asYaml(resources);
+            // Generate a possibly multi-document YAML
+            String yaml = resources.stream().map(FileUtils::asYaml).collect(Collectors.joining());
             try {
                 Files.writeString(kubernetesManifest, yaml);
             } catch (IOException e) {

--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/helm/HelmChartProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/helm/HelmChartProcessor.java
@@ -150,7 +150,8 @@ public class HelmChartProcessor {
                 return !r.getMetadata().getName().endsWith("-cluster-role");
             }
             if (r instanceof ClusterRoleBinding) {
-                return !r.getMetadata().getName().endsWith("-crd-validating-role-binding");
+                return !r.getMetadata().getName().endsWith("-crd-validating-role-binding") &&
+                        !r.getMetadata().getName().endsWith("-cluster-role-binding");
             }
             if (r instanceof RoleBinding) {
                 return !r.getMetadata().getName().equals(operatorName + "-view") &&

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/HelmChartWatchAllNamespacesGeneratorTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/HelmChartWatchAllNamespacesGeneratorTest.java
@@ -1,0 +1,64 @@
+package io.quarkiverse.operatorsdk.test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+import org.hamcrest.io.FileMatchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
+import io.quarkiverse.operatorsdk.common.FileUtils;
+import io.quarkiverse.operatorsdk.test.sources.SimpleCR;
+import io.quarkiverse.operatorsdk.test.sources.SimpleSpec;
+import io.quarkiverse.operatorsdk.test.sources.SimpleStatus;
+import io.quarkiverse.operatorsdk.test.sources.WatchAllNamespacesReconciler;
+import io.quarkus.test.ProdBuildResults;
+import io.quarkus.test.ProdModeTestResults;
+import io.quarkus.test.QuarkusProdModeTest;
+
+class HelmChartWatchAllNamespacesGeneratorTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setApplicationName("helm-chart-test-all-namespaces")
+            .withApplicationRoot(
+                    (jar) -> jar.addClasses(WatchAllNamespacesReconciler.class, SimpleCR.class,
+                            SimpleSpec.class, SimpleStatus.class))
+            .overrideConfigKey("quarkus.operator-sdk.helm.enabled", "true");
+
+    @ProdBuildResults
+    private ProdModeTestResults prodModeTestResults;
+
+    @Test
+    void generatesHelmChart() throws IOException {
+        Path buildDir = prodModeTestResults.getBuildDir();
+        var helmDir = new File(buildDir.toFile(), "helm");
+
+        assertThat(new File(helmDir, "Chart.yaml"), FileMatchers.anExistingFile());
+        assertThat(new File(helmDir, "values.yaml"), FileMatchers.anExistingFile());
+
+        File templatesDir = new File(helmDir, "templates");
+
+        assertThat(Objects.requireNonNull(templatesDir.listFiles()).length, equalTo(8));
+
+        File kubernetesYml = new File(templatesDir, "kubernetes.yml");
+        assertThat(kubernetesYml, FileMatchers.anExistingFile());
+        String kubernetesYmlContents = Files.readString(kubernetesYml.toPath());
+        HasMetadata resource = (HasMetadata) FileUtils.unmarshalFrom(
+                kubernetesYmlContents.getBytes(StandardCharsets.UTF_8));
+        assertThat(resource, instanceOf(ClusterRoleBinding.class));
+        assertThat(resource.getMetadata().getName(),
+                equalTo("all-namespaces-reconciler-cluster-role-binding"));
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/HelmChartWatchAllNamespacesGeneratorTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/HelmChartWatchAllNamespacesGeneratorTest.java
@@ -1,14 +1,14 @@
 package io.quarkiverse.operatorsdk.test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 
 import org.hamcrest.io.FileMatchers;
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.rbac.ClusterRoleBinding;
 import io.quarkiverse.operatorsdk.common.FileUtils;
 import io.quarkiverse.operatorsdk.test.sources.SimpleCR;
 import io.quarkiverse.operatorsdk.test.sources.SimpleSpec;
@@ -34,6 +33,35 @@ class HelmChartWatchAllNamespacesGeneratorTest {
             .withApplicationRoot(
                     (jar) -> jar.addClasses(WatchAllNamespacesReconciler.class, SimpleCR.class,
                             SimpleSpec.class, SimpleStatus.class))
+            // Generate some custom resources to test that they get properly included in the Helm chart
+            // ServiceAccount
+            .overrideConfigKey("quarkus.kubernetes.rbac.service-accounts.service-account-custom.namespace", "custom-ns")
+            // Role
+            .overrideConfigKey("quarkus.kubernetes.rbac.roles.role-custom.policy-rules.0.api-groups", "extensions,apps")
+            .overrideConfigKey("quarkus.kubernetes.rbac.roles.role-custom.policy-rules.0.resources", "deployments")
+            .overrideConfigKey("quarkus.kubernetes.rbac.roles.role-custom.policy-rules.0.verbs", "get,watch,list")
+            // RoleBinding
+            .overrideConfigKey("quarkus.kubernetes.rbac.role-bindings.role-binding-custom.subjects.service-account-custom.kind",
+                    "ServiceAccount")
+            .overrideConfigKey(
+                    "quarkus.kubernetes.rbac.role-bindings.role-binding-custom.subjects.service-account-custom.namespace",
+                    "custom-ns")
+            .overrideConfigKey("quarkus.kubernetes.rbac.role-bindings.role-binding-custom.role-name", "role-custom")
+            // ClusterRole
+            .overrideConfigKey("quarkus.kubernetes.rbac.cluster-roles.cluster-role-custom.policy-rules.0.api-groups",
+                    "extensions,apps")
+            .overrideConfigKey("quarkus.kubernetes.rbac.cluster-roles.cluster-role-custom.policy-rules.0.resources",
+                    "deployments")
+            .overrideConfigKey("quarkus.kubernetes.rbac.cluster-roles.cluster-role-custom.policy-rules.0.verbs",
+                    "get,watch,list")
+            // ClusterRoleBinding
+            .overrideConfigKey(
+                    "quarkus.kubernetes.rbac.cluster-role-bindings.cluster-role-binding-custom.subjects.manager.kind", "Group")
+            .overrideConfigKey(
+                    "quarkus.kubernetes.rbac.cluster-role-bindings.cluster-role-binding-custom.subjects.manager.api-group",
+                    "rbac.authorization.k8s.io")
+            .overrideConfigKey("quarkus.kubernetes.rbac.cluster-role-bindings.cluster-role-binding-custom.role-name",
+                    "custom-cluster-role")
             .overrideConfigKey("quarkus.operator-sdk.helm.enabled", "true");
 
     @ProdBuildResults
@@ -54,11 +82,16 @@ class HelmChartWatchAllNamespacesGeneratorTest {
         File kubernetesYml = new File(templatesDir, "kubernetes.yml");
         assertThat(kubernetesYml, FileMatchers.anExistingFile());
         String kubernetesYmlContents = Files.readString(kubernetesYml.toPath());
-        HasMetadata resource = (HasMetadata) FileUtils.unmarshalFrom(
+        @SuppressWarnings("unchecked")
+        List<HasMetadata> resource = (List<HasMetadata>) FileUtils.unmarshalFrom(
                 kubernetesYmlContents.getBytes(StandardCharsets.UTF_8));
-        assertThat(resource, instanceOf(ClusterRoleBinding.class));
-        assertThat(resource.getMetadata().getName(),
-                equalTo("all-namespaces-reconciler-cluster-role-binding"));
+        assertThat(resource, hasSize(5));
+        assertThat(resource, containsInAnyOrder(
+                hasProperty("kind", equalTo("ServiceAccount")),
+                hasProperty("kind", equalTo("Role")),
+                hasProperty("kind", equalTo("RoleBinding")),
+                hasProperty("kind", equalTo("ClusterRole")),
+                hasProperty("kind", equalTo("ClusterRoleBinding"))));
     }
 
 }

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/WatchAllNamespacesReconciler.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/WatchAllNamespacesReconciler.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.operatorsdk.test.sources;
+
+import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_ALL_NAMESPACES;
+
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
+
+@ControllerConfiguration(name = WatchAllNamespacesReconciler.NAME, namespaces = WATCH_ALL_NAMESPACES)
+public class WatchAllNamespacesReconciler implements Reconciler<SimpleCR> {
+
+    public static final String NAME = "all-namespaces-reconciler";
+
+    @Override
+    public UpdateControl<SimpleCR> reconcile(SimpleCR simpleCR, Context<SimpleCR> context) {
+        return null;
+    }
+}


### PR DESCRIPTION
When a reconciler is configured to watch all namespaces, a ClusterRoleBinding object is generated by
AddRoleBindingsDecorator, and it later gets appended to templates/kubernetes.yml by HelmChartProcessor.

However, that file becomes syntactically invalid because FileUtils.asYaml produces a top-level YAML array when passed a List. That's not what Helm expects.

When one tries to install the generated chart, the following error is returned:

     Error: INSTALLATION FAILED: YAML parse error on
     [...]/templates/kubernetes.yml: error unmarshaling JSON:
     while decoding JSON: json: cannot unmarshal array into
     Go value of type releaseutil.SimpleHead
     YAML parse error on [...]/templates/kubernetes.yml