### PR TITLE
Support typeless kubernetes resources when generating manifests

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/AddClusterRolesDecorator.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/AddClusterRolesDecorator.java
@@ -133,6 +133,12 @@ public class AddClusterRolesDecorator extends ResourceProvidingDecorator<Kuberne
         return clusterRoleBuilder.build();
     }
 
+    /**
+     * Remove duplicated rules with same groups and resources, from which merge all verbs
+     *
+     * @param collectedRules may contain duplicated rules with same groups and resources, but different verbs
+     * @return no duplicated rules
+     */
     @NotNull
     private static Set<PolicyRule> getNormalizedRules(Set<PolicyRule> collectedRules) {
         Set<PolicyRule> normalizedRules = new LinkedHashSet<>();

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
@@ -99,6 +99,8 @@ public class OperatorSDKTest {
                             .filter(rule -> rule.getResources().equals(List.of(RBACRule.ALL)))
                             .anyMatch(rule -> rule.getVerbs().equals(List.of(UPDATE))
                                     && rule.getApiGroups().equals(List.of(RBACRule.ALL))));
+
+                    // TODO: need update, https://github.com/operator-framework/java-operator-sdk/pull/2515
                     // expected generic kubernetes resource: apiGroups is Group from GVK and resources should be '*'
                     // verbs should contain merged 'delete'
                     // count should be 1, as TypelessKubeResource and TypelessAnotherKubeResource have same GROUP

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/OperatorSDKTest.java
@@ -99,8 +99,14 @@ public class OperatorSDKTest {
                             .filter(rule -> rule.getResources().equals(List.of(RBACRule.ALL)))
                             .anyMatch(rule -> rule.getVerbs().equals(List.of(UPDATE))
                                     && rule.getApiGroups().equals(List.of(RBACRule.ALL))));
-                    rules.stream().filter(rule -> rule.getApiGroups().equals(List.of(TypelessKubeResource.GROUP)))
-                            .anyMatch(rule -> rule.getResources().equals(List.of("*")));
+                    // expected generic kubernetes resource: apiGroups is Group from GVK and resources should be '*'
+                    // verbs should contain merged 'delete'
+                    // count should be 1, as TypelessKubeResource and TypelessAnotherKubeResource have same GROUP
+                    assertTrue(rules.stream()
+                            .filter(rule -> rule.getApiGroups().equals(List.of(TypelessKubeResource.GROUP)))
+                            .filter(rule -> rule.getResources().equals(List.of("*")))
+                            .filter(rule -> rule.getVerbs().contains("delete"))
+                            .count() == 1);
                 });
 
         // check that we have a role binding for TestReconciler and that it uses the operator-level specified namespace

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/TestReconciler.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/TestReconciler.java
@@ -12,7 +12,9 @@ import io.quarkiverse.operatorsdk.annotations.RBACVerbs;
         @Dependent(type = CRUDConfigMap.class),
         @Dependent(type = ReadOnlySecret.class),
         @Dependent(type = CreateOnlyService.class),
-        @Dependent(type = NonKubeResource.class)
+        @Dependent(type = NonKubeResource.class),
+        @Dependent(type = TypelessKubeResource.class),
+        @Dependent(type = TypelessAnotherKubeResource.class)
 })
 @RBACRule(verbs = RBACVerbs.UPDATE, apiGroups = RBACRule.ALL, resources = RBACRule.ALL)
 public class TestReconciler implements Reconciler<TestCR> {

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/TypelessAnotherKubeResource.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/TypelessAnotherKubeResource.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.operatorsdk.test.sources;
+
+import io.javaoperatorsdk.operator.api.reconciler.dependent.Deleter;
+import io.javaoperatorsdk.operator.processing.GroupVersionKind;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.GenericKubernetesDependentResource;
+
+public class TypelessAnotherKubeResource extends GenericKubernetesDependentResource<TestCR> implements Deleter<TestCR> {
+
+    public static final String GROUP = "crd.josdk.quarkiverse.io";
+    public static final String KIND = "typelessAnother";
+    public static final String VERSION = "v1";
+    private static final GroupVersionKind GVK = new GroupVersionKind(GROUP, VERSION, KIND);
+
+    public TypelessAnotherKubeResource() {
+        super(GVK);
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/TypelessKubeResource.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/TypelessKubeResource.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.operatorsdk.test.sources;
+
+import io.javaoperatorsdk.operator.processing.GroupVersionKind;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.GenericKubernetesDependentResource;
+
+public class TypelessKubeResource extends GenericKubernetesDependentResource<TestCR> {
+
+    public static final String GROUP = "crd.josdk.quarkiverse.io";
+    public static final String KIND = "typeless";
+    public static final String VERSION = "v1";
+    private static final GroupVersionKind GVK = new GroupVersionKind(GROUP, VERSION, KIND);
+
+    public TypelessKubeResource() {
+        super(GVK);
+    }
+
+}


### PR DESCRIPTION
Typeless kubernetes resource has no Group and Plural value, so generating wrong policy rule.

Commit summary:
1) Use ApiGroup value from GVK and '*' for Plural value if dependent resource is assignable from GenericKubernetesDependentResource 2) Merge verbs in rule for optimization if with same ApiGroups and Resources