### PR TITLE
fix: Remove duplicate CSV nativeAPIs, sort by multi-field comparator

### DIFF
--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
@@ -79,7 +79,9 @@ public class MultipleOperatorsBundleTest {
         assertEquals(HasMetadata.getFullResourceName(SecondExternal.class), crds.getRequired().get(1).getName());
         // should list native APIs as well
         final var spec = csv.getSpec();
-        final var podGVK = spec.getNativeAPIs().get(0);
+        final var nativeAPIs = spec.getNativeAPIs();
+        assertEquals(1, nativeAPIs.size());
+        final var podGVK = nativeAPIs.get(0);
         assertEquals(HasMetadata.getGroup(Pod.class), podGVK.getGroup());
         assertEquals(HasMetadata.getKind(Pod.class), podGVK.getKind());
         assertEquals(HasMetadata.getVersion(Pod.class), podGVK.getVersion());

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/ThirdReconciler.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/ThirdReconciler.java
@@ -14,7 +14,8 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata.RequiredCRD;
         + SecondExternal.GROUP, version = SecondExternal.VERSION), replaces = "1.0.0", annotations = @Annotations(skipRange = ">=1.0.0 <1.0.3", capabilities = "Test", others = @Annotation(name = "foo", value = "bar")))
 @ControllerConfiguration(name = ThirdReconciler.NAME, dependents = {
         @Dependent(type = ExternalDependentResource.class),
-        @Dependent(type = PodDependentResource.class)
+        @Dependent(name = "pod1", type = PodDependentResource.class),
+        @Dependent(name = "pod2", type = PodDependentResource.class)
 })
 public class ThirdReconciler implements Reconciler<Third> {
 


### PR DESCRIPTION
This PR removes duplicate entries from the generated CSV's `spec.nativeAPIs` array.

Currently, output like the following may occur when multiple dependent resources handle native k8s types of the same kind, such as [1].
```yaml
...
spec:
  ...
  nativeAPIs:
    - kind: ConfigMap
      group: ""
      version: v1
    - kind: Secret
      group: ""
      version: v1
    - kind: ServiceAccount
      group: ""
      version: v1
    - kind: ServiceAccount
      group: ""
      version: v1
    - kind: Service
      group: ""
      version: v1
    - kind: Service
      group: ""
      version: v1
    - kind: Deployment
      group: apps
      version: v1
    - kind: Deployment
      group: apps
      version: v1
    - kind: Ingress
      group: networking.k8s.io
      version: v1
    - kind: ClusterRoleBinding
      group: rbac.authorization.k8s.io
      version: v1
    - kind: ClusterRoleBinding
      group: rbac.authorization.k8s.io
      version: v1
    - kind: ClusterRole
      group: rbac.authorization.k8s.io
      version: v1
    - kind: ClusterRole
      group: rbac.authorization.k8s.io
      version: v1
  ...
```

[1] https://github.com/streamshub/console/tree/main/operator/src/main/java/com/github/streamshub/console/dependents