### PR TITLE
chore: remove now unneeded workaround after Quarkus 3.15.2 update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <packaging>pom</packaging>
   <name>Quarkus - Operator SDK - Parent</name>
   <properties>
-    <quarkus.version>3.15.1</quarkus.version>
+    <quarkus.version>3.15.2</quarkus.version>
     <java-operator-sdk.version>4.9.6</java-operator-sdk.version>
   </properties>
   <scm>

--- a/samples/exposedapp/src/main/resources/application.properties
+++ b/samples/exposedapp/src/main/resources/application.properties
@@ -13,6 +13,3 @@ quarkus.http.test-port=0
 
 quarkus.kubernetes-client.devservices.enabled=true
 quarkus.operator-sdk.helm.enabled=true
-
-# todo: remove workaround for https://github.com/quarkusio/quarkus/issues/43474 when fixed
-quarkus.kubernetes-client.request-retry-backoff-limit=10

--- a/samples/joke/src/main/resources/application.properties
+++ b/samples/joke/src/main/resources/application.properties
@@ -5,6 +5,3 @@ quarkus.operator-sdk.bundle.channels=alpha
 quarkus.operator-sdk.crd.generate-all=true
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
 quarkus.http.test-port=0
-
-# todo: remove workaround for https://github.com/quarkusio/quarkus/issues/43474 when fixed
-quarkus.kubernetes-client.request-retry-backoff-limit=10

--- a/samples/mysql-schema/src/main/resources/application.properties
+++ b/samples/mysql-schema/src/main/resources/application.properties
@@ -5,6 +5,3 @@ quarkus.datasource.username=root
 quarkus.datasource.devservices.image-name=mariadb:10.7
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
 quarkus.http.test-port=0
-
-# todo: remove workaround for https://github.com/quarkusio/quarkus/issues/43474 when fixed
-quarkus.kubernetes-client.request-retry-backoff-limit=10

--- a/samples/pingpong/src/main/resources/application.properties
+++ b/samples/pingpong/src/main/resources/application.properties
@@ -3,6 +3,3 @@ quarkus.container-image.builder=jib
 quarkus.operator-sdk.bundle.channels=alpha
 quarkus.kubernetes-client.devservices.override-kubeconfig=true
 quarkus.http.test-port=0
-
-# todo: remove workaround for https://github.com/quarkusio/quarkus/issues/43474 when fixed
-quarkus.kubernetes-client.request-retry-backoff-limit=10


### PR DESCRIPTION
- **chore: remove now unneeded workaround**
- **chore(deps): update to Quarkus 3.15.2**
