### PR TITLE
feat: Add possibility to override deployment image

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/helm/Values.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/helm/Values.java
@@ -5,6 +5,7 @@ import static io.javaoperatorsdk.operator.api.reconciler.Constants.WATCH_ALL_NAM
 public class Values {
 
     private String watchNamespaces = WATCH_ALL_NAMESPACES;
+    private String image = "";
 
     public String getWatchNamespaces() {
         return watchNamespaces;
@@ -12,6 +13,15 @@ public class Values {
 
     public Values setWatchNamespaces(String watchNamespaces) {
         this.watchNamespaces = watchNamespaces;
+        return this;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public Values setImage(String image) {
+        this.image = image;
         return this;
     }
 }


### PR DESCRIPTION
With this a new property `image` is added to the `values.yaml` so that the users can override it if need. 

Tested with Debezium Operator.
 
```yaml
---
apiVersion: "apps/v1"
kind: "Deployment"
metadata:
  annotations:
    app.quarkus.io/quarkus-version: "3.17.0"
  labels:
    app.kubernetes.io/name: "debezium-operator"
    app.kubernetes.io/managed-by: "quarkus"
  name: "debezium-operator"
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: "debezium-operator"
  template:
    metadata:
      annotations:
        app.quarkus.io/quarkus-version: "3.17.0"
      labels:
        app.kubernetes.io/managed-by: "quarkus"
        app.kubernetes.io/name: "debezium-operator"
    spec:
      containers:
      - env:
        - name: "KUBERNETES_NAMESPACE"
          valueFrom:
            fieldRef:
              fieldPath: "metadata.namespace"
        - name: "QUARKUS_OPERATOR_SDK_CONTROLLERS_DEBEZIUMSERVER_NAMESPACES"
          value: {{ .Values.watchNamespaces }}
        image: {{ .Values.image }}
        imagePullPolicy: "Always"
        livenessProbe:
          failureThreshold: 3
          httpGet:
            path: "/q/health/live"
            port: 8080
            scheme: "HTTP"
          initialDelaySeconds: 5
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 10
        name: "debezium-operator"
        ports:
        - containerPort: 8080
          name: "http"
          protocol: "TCP"
        readinessProbe:
          failureThreshold: 3
          httpGet:
            path: "/q/health/ready"
            port: 8080
            scheme: "HTTP"
          initialDelaySeconds: 5
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 10
        startupProbe:
          failureThreshold: 3
          httpGet:
            path: "/q/health/started"
            port: 8080
            scheme: "HTTP"
          initialDelaySeconds: 5
          periodSeconds: 10
          successThreshold: 1
          timeoutSeconds: 10
      serviceAccountName: "debezium-operator"
```


```yaml
---
watchNamespaces: "JOSDK_ALL_NAMESPACES"
image: "quay.io/debezium/operator:nightly"
```