### PR TITLE
Allow triggering the prepare-release workflow manually

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,6 +1,7 @@
 name: Quarkiverse Prepare Release
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [ closed ]
     paths:
@@ -13,6 +14,6 @@ concurrency:
 jobs:
   prepare-release:
     name: Prepare Release
-    if: ${{ github.event.pull_request.merged == true}}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true}}
     uses: quarkiverse/.github/.github/workflows/prepare-release.yml@main
     secrets: inherit


### PR DESCRIPTION
This allows you to retry failed releases without the need to revert changes to `.github/project.yml`

- See https://github.com/quarkusio/quarkus/pull/45036