### PR TITLE
Remove performRelease profile

### DIFF
--- a/.github/workflows/release-snapshot-old.yml
+++ b/.github/workflows/release-snapshot-old.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Deploy maven snapshot
         run: |
-          ./mvnw -B deploy -DperformRelease -Dno-samples -Dno-docs -Prelease,use-snapshots
+          ./mvnw -B deploy -Dno-samples -Dno-docs -Prelease,use-snapshots
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -95,17 +95,6 @@
         <module>samples</module>
       </modules>
     </profile>
-  <profile>
-      <id>no-samples-in-release</id>
-      <activation>
-        <property>
-          <name>!performRelease</name>
-        </property>
-      </activation>
-      <modules>
-        <module>samples</module>
-      </modules>
-    </profile>
     <profile>
       <id>no-docs</id>
       <activation>


### PR DESCRIPTION
This is is duplicating no-samples profile and the only place that it is used for also defines `-Dno-samples` so it's impossible to skip samples unless ran as -> `-DperformRelease -Dno-samples` which is just redundant.