### PR TITLE
fix: remove test-kubernetes-client from the joke sample to use provided Dev Services

### DIFF
--- a/samples/joke/pom.xml
+++ b/samples/joke/pom.xml
@@ -61,11 +61,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-test-kubernetes-client</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>

--- a/samples/joke/src/test/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconcilerTest.java
+++ b/samples/joke/src/test/java/io/quarkiverse/operatorsdk/samples/joke/JokeRequestReconcilerTest.java
@@ -22,7 +22,6 @@ import org.mockito.Mockito;
 
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.javaoperatorsdk.operator.Operator;
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestSpec.Category;
 import io.quarkiverse.operatorsdk.samples.joke.JokeRequestStatus.State;
 import io.quarkus.test.InjectMock;
@@ -38,13 +37,8 @@ class JokeRequestReconcilerTest {
     @Inject
     KubernetesClient client;
 
-    @Inject
-    Operator operator;
-
     @Test
     void canReconcile() {
-        operator.start();
-
         // arrange
         final JokeModel joke = new JokeModel();
         joke.id = 1;


### PR DESCRIPTION
It seems that before https://github.com/quarkusio/quarkus/pull/48977 the `quarkus-test-kubernetes-client` was not correctly recognized and the Kubernetes Client Dev Services were able to start the container. But after this change the extension presence is correctly detected and thus the containers are not started.