### PR TITLE
fix: inject RunTimeOperatorConfiguration as RuntimeValue

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/OperatorSDKProcessor.java
@@ -33,7 +33,6 @@ import io.quarkiverse.operatorsdk.runtime.OperatorHealthCheck;
 import io.quarkiverse.operatorsdk.runtime.OperatorProducer;
 import io.quarkiverse.operatorsdk.runtime.QuarkusBuildTimeControllerConfiguration;
 import io.quarkiverse.operatorsdk.runtime.QuarkusConfigurationService;
-import io.quarkiverse.operatorsdk.runtime.RunTimeOperatorConfiguration;
 import io.quarkiverse.operatorsdk.runtime.api.ConfigurableReconciler;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
@@ -149,13 +148,11 @@ class OperatorSDKProcessor {
     void updateControllerConfigurations(
             BuildTimeConfigurationServiceBuildItem buildTimeConfigurationServiceBuildItem,
             ConfigurationServiceRecorder recorder,
-            RunTimeOperatorConfiguration runTimeConfiguration,
             BuildProducer<SyntheticBeanBuildItem> syntheticBeanBuildItemBuildProducer,
             ControllerConfigurationsBuildItem controllerConfigurations) {
         final var supplier = recorder.configurationServiceSupplier(
                 buildTimeConfigurationServiceBuildItem.getConfigurationService(),
-                controllerConfigurations.getControllerConfigs(),
-                runTimeConfiguration);
+                controllerConfigurations.getControllerConfigs());
         syntheticBeanBuildItemBuildProducer.produce(
                 SyntheticBeanBuildItem.configure(QuarkusConfigurationService.class)
                         .scope(Singleton.class)

--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/ConfigurationServiceRecorder.java
@@ -17,6 +17,7 @@ import io.javaoperatorsdk.operator.api.config.InformerStoppedHandler;
 import io.javaoperatorsdk.operator.api.config.LeaderElectionConfiguration;
 import io.javaoperatorsdk.operator.api.monitoring.Metrics;
 import io.quarkus.arc.Arc;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.quarkus.runtime.configuration.ConfigUtils;
 
@@ -24,12 +25,17 @@ import io.quarkus.runtime.configuration.ConfigUtils;
 public class ConfigurationServiceRecorder {
 
     static final Logger log = Logger.getLogger(ConfigurationServiceRecorder.class.getName());
+    private final RuntimeValue<RunTimeOperatorConfiguration> runTimeConfigurationRuntimeValue;
+
+    public ConfigurationServiceRecorder(RuntimeValue<RunTimeOperatorConfiguration> runTimeConfigurationRuntimeValue) {
+        this.runTimeConfigurationRuntimeValue = runTimeConfigurationRuntimeValue;
+    }
 
     @SuppressWarnings({ "rawtypes", "unchecked", "resource" })
     public Supplier<QuarkusConfigurationService> configurationServiceSupplier(
             BuildTimeConfigurationService buildTimeConfigurationService,
-            Map<String, QuarkusBuildTimeControllerConfiguration<?>> configurations,
-            RunTimeOperatorConfiguration runTimeConfiguration) {
+            Map<String, QuarkusBuildTimeControllerConfiguration<?>> configurations) {
+        final var runTimeConfiguration = runTimeConfigurationRuntimeValue.getValue();
         final var maxThreads = runTimeConfiguration.concurrentReconciliationThreads()
                 .orElse(ConfigurationService.DEFAULT_RECONCILIATION_THREADS_NUMBER);
         final var timeout = runTimeConfiguration.terminationTimeoutSeconds()


### PR DESCRIPTION
Fixes #1141 

I don't understand why that docs changes got there when I built the project. But they are staying there so I'm keeping them in this PR.