### PR TITLE
fix: override getSecondaryResource to properly get associated resource

### DIFF
--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaReconciler.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaReconciler.java
@@ -19,12 +19,11 @@ import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
 import io.quarkus.logging.Log;
 
 @Workflow(dependents = {
-        @Dependent(type = SecretDependentResource.class),
-        @Dependent(type = SchemaDependentResource.class, name = SchemaDependentResource.NAME)
+        @Dependent(type = SecretDependentResource.class, name = SecretDependentResource.DEPENDENT_NAME),
+        @Dependent(type = SchemaDependentResource.class, dependsOn = SecretDependentResource.DEPENDENT_NAME)
 })
 @SuppressWarnings("unused")
 public class MySQLSchemaReconciler implements Reconciler<MySQLSchema> {
-
     @Inject
     SchemaService schemaService;
 
@@ -33,7 +32,7 @@ public class MySQLSchemaReconciler implements Reconciler<MySQLSchema> {
         // we only need to update the status if we just built the schema, i.e. when it's
         // present in the context
         return context.getSecondaryResource(Secret.class)
-                .map(secret -> context.getSecondaryResource(Schema.class, SchemaDependentResource.NAME)
+                .map(secret -> context.getSecondaryResource(Schema.class)
                         .map(s -> {
                             updateStatusPojo(schema, secret.getMetadata().getName(),
                                     decode(secret.getData().get(MYSQL_SECRET_USERNAME)));

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/dependent/SecretDependentResource.java
@@ -17,7 +17,7 @@ import io.quarkiverse.operatorsdk.samples.mysqlschema.MySQLSchema;
 @ApplicationScoped
 public class SecretDependentResource extends KubernetesDependentResource<Secret, MySQLSchema>
         implements Creator<Secret, MySQLSchema> {
-
+    public static final String DEPENDENT_NAME = "secret-dependent";
     public static final String SECRET_FORMAT = "%s-secret";
     public static final String USERNAME_FORMAT = "%s-user";
     public static final String MYSQL_SECRET_USERNAME = "mysql.secret.user.name";

--- a/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/Schema.java
+++ b/samples/mysql-schema/src/main/java/io/quarkiverse/operatorsdk/samples/mysqlschema/schema/Schema.java
@@ -35,4 +35,9 @@ public class Schema implements Serializable {
     public int hashCode() {
         return Objects.hash(name, characterSet);
     }
+
+    @Override
+    public String toString() {
+        return "Schema{" + "name='" + name + '\'' + ", characterSet='" + characterSet + "'}";
+    }
 }

--- a/samples/mysql-schema/src/test/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaOperatorE2ETest.java
+++ b/samples/mysql-schema/src/test/java/io/quarkiverse/operatorsdk/samples/mysqlschema/MySQLSchemaOperatorE2ETest.java
@@ -7,11 +7,14 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
 
 import jakarta.inject.Inject;
 
@@ -23,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.javaoperatorsdk.operator.Operator;
+import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.Schema;
 import io.quarkiverse.operatorsdk.samples.mysqlschema.schema.SchemaService;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.mockito.InjectSpy;
@@ -31,6 +35,8 @@ import io.quarkus.test.junit.mockito.InjectSpy;
 class MySQLSchemaOperatorE2ETest {
 
     final static Logger log = Logger.getLogger(MySQLSchemaOperatorE2ETest.class);
+    private static final String DB_NAME = "mydb1";
+    private static final String ENCODING = "utf8";
 
     @InjectSpy
     SchemaService schemaService;
@@ -54,19 +60,24 @@ class MySQLSchemaOperatorE2ETest {
     @Test
     void test() {
 
+        final Optional<Schema> maybeSchema = schemaService.getSchema(DB_NAME);
+        if (maybeSchema.isPresent()) {
+            fail("Schema " + DB_NAME + " should not already exist");
+        }
+
         MySQLSchema testSchema = new MySQLSchema();
         testSchema.setMetadata(new ObjectMetaBuilder()
-                .withName("mydb1")
+                .withName(DB_NAME)
                 .withNamespace(client.getNamespace())
                 .build());
         testSchema.setSpec(new SchemaSpec());
-        testSchema.getSpec().setEncoding("utf8");
+        testSchema.getSpec().setEncoding(ENCODING);
 
         log.infof("Creating test MySQLSchema object: %s", testSchema);
         client.resource(testSchema).serverSideApply();
 
         log.info("Waiting 10 seconds for expected resources to be created and updated");
-        await().atMost(10, SECONDS).untilAsserted(() -> {
+        await().pollDelay(9, SECONDS).atMost(10, SECONDS).untilAsserted(() -> {
             MySQLSchema updatedSchema = client.resources(MySQLSchema.class)
                     .inNamespace(testSchema.getMetadata().getNamespace())
                     .withName(testSchema.getMetadata().getName()).get();
@@ -77,7 +88,7 @@ class MySQLSchemaOperatorE2ETest {
             assertThat(updatedSchema.getStatus().getUrl(), startsWith("jdbc:mysql://"));
         });
 
-        verify(schemaService, times(1)).createSchemaAndRelatedUser(any(), eq("mydb1"), eq("utf8"), anyString(),
+        verify(schemaService, times(1)).createSchemaAndRelatedUser(any(), eq(DB_NAME), eq(ENCODING), anyString(),
                 anyString());
 
         client.resource(testSchema).delete();
@@ -95,6 +106,6 @@ class MySQLSchemaOperatorE2ETest {
                             assertThat(updatedSchema, is(nullValue()));
                         });
 
-        verify(schemaService, times(1)).deleteSchemaAndRelatedUser(any(), eq("mydb1"), anyString());
+        verify(schemaService, times(1)).deleteSchemaAndRelatedUser(any(), eq(DB_NAME), anyString());
     }
 }


### PR DESCRIPTION
- **fix: override getSecondaryResource to properly get associated resource**
- **refactor: use constants instead of hardcoding values**
- **feat: fail if schema already exists in DB**
- **feat: add toString implementation**
- **feat: wait for secret before attempting to create the schema**
