### PR TITLE
feat: make it possible to mark dependents as optional

### DIFF
--- a/annotations/src/main/java/io/quarkiverse/operatorsdk/annotations/CSVMetadata.java
+++ b/annotations/src/main/java/io/quarkiverse/operatorsdk/annotations/CSVMetadata.java
@@ -174,4 +174,14 @@ public @interface CSVMetadata {
 
         String name();
     }
+
+    /**
+     * Whether the associated resource is explicitly marked as optional, i.e. the operator can work without it being present on
+     * the cluster. This will have the effect of not requiring the associated resource in the generated OLM bundle.
+     *
+     * @since 7.3.0
+     */
+    @interface Optional {
+        boolean value() default true;
+    }
 }

--- a/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
+++ b/bundle-generator/deployment/src/main/java/io/quarkiverse/operatorsdk/bundle/deployment/builders/CsvManifestsBuilder.java
@@ -207,6 +207,7 @@ public class CsvManifestsBuilder extends ManifestsBuilder {
             final var dependents = raci.getDependentResourceInfos();
             if (dependents != null && !dependents.isEmpty()) {
                 dependents.stream()
+                        .filter(draci -> !draci.isOptional())
                         .map(ResourceAssociatedAugmentedClassInfo::associatedResourceInfo)
                         .filter(ReconciledAugmentedClassInfo::isResource)
                         .map(ReconciledAugmentedClassInfo::asResourceTargeting)

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/MultipleOperatorsBundleTest.java
@@ -37,7 +37,8 @@ public class MultipleOperatorsBundleTest {
                     .addClasses(First.class, FirstReconciler.class,
                             Second.class, SecondReconciler.class,
                             Third.class, External.class, SecondExternal.class, ThirdReconciler.class,
-                            ExternalDependentResource.class, PodDependentResource.class))
+                            ExternalDependentResource.class, PodDependentResource.class, OptionalImplicitNativeDependent.class,
+                            OptionalExplicitNativeDependent.class))
             .overrideConfigKey("quarkus.operator-sdk.crd.generate-all", "true")
             .overrideConfigKey("quarkus.operator-sdk.bundle.replaces", FirstReconciler.REPLACES)
             .overrideConfigKey("quarkus.operator-sdk.bundle.bundles." + ThirdReconciler.BUNDLE_NAME + ".annotations."

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/OptionalExplicitNativeDependent.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/OptionalExplicitNativeDependent.java
@@ -1,0 +1,9 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import io.fabric8.openshift.api.model.monitoring.v1.ServiceMonitor;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
+
+@CSVMetadata.Optional
+public class OptionalExplicitNativeDependent extends KubernetesDependentResource<ServiceMonitor, Third> {
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/OptionalImplicitNativeDependent.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/OptionalImplicitNativeDependent.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.operatorsdk.bundle.sources;
+
+import io.fabric8.kubernetes.api.model.Secret;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.dependent.DependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.kubernetes.KubernetesDependentResource;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.CRDPresentActivationCondition;
+
+public class OptionalImplicitNativeDependent extends KubernetesDependentResource<Secret, Third> {
+    public static class ActivationCondition extends CRDPresentActivationCondition<Secret, Third> {
+        @Override
+        public boolean isMet(DependentResource<Secret, Third> dependentResource, Third primary, Context<Third> context) {
+            return false;
+        }
+    }
+}

--- a/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/ThirdReconciler.java
+++ b/bundle-generator/deployment/src/test/java/io/quarkiverse/operatorsdk/bundle/sources/ThirdReconciler.java
@@ -6,6 +6,7 @@ import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
 import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 import io.javaoperatorsdk.operator.api.reconciler.Workflow;
 import io.javaoperatorsdk.operator.api.reconciler.dependent.Dependent;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.CRDPresentActivationCondition;
 import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
 import io.quarkiverse.operatorsdk.annotations.CSVMetadata.Annotations;
 import io.quarkiverse.operatorsdk.annotations.CSVMetadata.Annotations.Annotation;
@@ -15,7 +16,10 @@ import io.quarkiverse.operatorsdk.annotations.CSVMetadata.RequiredCRD;
 @Workflow(dependents = {
         @Dependent(type = ExternalDependentResource.class),
         @Dependent(name = "pod1", type = PodDependentResource.class),
-        @Dependent(name = "pod2", type = PodDependentResource.class)
+        @Dependent(name = "pod2", type = PodDependentResource.class),
+        @Dependent(type = OptionalExplicitNativeDependent.class),
+        @Dependent(type = OptionalImplicitNativeDependent.class, name = "implicit1", activationCondition = OptionalImplicitNativeDependent.ActivationCondition.class),
+        @Dependent(type = OptionalImplicitNativeDependent.class, name = "implicit2", activationCondition = CRDPresentActivationCondition.class),
 })
 @CSVMetadata(bundleName = ThirdReconciler.BUNDLE_NAME, requiredCRDs = @RequiredCRD(kind = SecondExternal.KIND, name = "externalagains."
         + SecondExternal.GROUP, version = SecondExternal.VERSION), replaces = "1.0.0", annotations = @Annotations(skipRange = ">=1.0.0 <1.0.3", capabilities = "Test", repository = "should be overridden by property", others = @Annotation(name = "foo", value = "bar")), labels = {

--- a/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/DependentResourceAugmentedClassInfo.java
+++ b/common-deployment/src/main/java/io/quarkiverse/operatorsdk/common/DependentResourceAugmentedClassInfo.java
@@ -9,11 +9,21 @@ import java.util.function.Predicate;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.logging.Logger;
 
+import io.javaoperatorsdk.operator.processing.dependent.workflow.CRDPresentActivationCondition;
+import io.javaoperatorsdk.operator.processing.dependent.workflow.Condition;
+import io.quarkiverse.operatorsdk.annotations.CSVMetadata;
+import io.quarkus.builder.BuildException;
+import io.quarkus.deployment.util.JandexUtil;
+
 public class DependentResourceAugmentedClassInfo extends ResourceAssociatedAugmentedClassInfo {
+    private static final DotName CRD_CHECKING_CONDITION = DotName.createSimple(CRDPresentActivationCondition.class);
+    private static final DotName OPTIONAL_ANNOTATION = DotName.createSimple(CSVMetadata.Optional.class);
     private final AnnotationInstance dependentAnnotationFromController;
+    private boolean optional;
 
     public DependentResourceAugmentedClassInfo(ClassInfo classInfo) {
         this(classInfo, null, null);
@@ -38,6 +48,44 @@ public class DependentResourceAugmentedClassInfo extends ResourceAssociatedAugme
         final var info = new DependentResourceAugmentedClassInfo(classInfo, dependentAnnotationFromController, reconcilerName);
         info.augmentIfKept(index, log, context);
         return info;
+    }
+
+    @Override
+    protected void doAugment(IndexView index, Logger log, Map<String, Object> context) {
+        super.doAugment(index, log, context);
+
+        // only check if dependent has an activation condition that derives from the CRD checking one here
+        final var activationConditionType = getDependentAnnotationFromController().value("activationCondition");
+        if (activationConditionType != null) {
+            final var conditionInfo = ConfigurationUtils.getClassInfoForInstantiation(activationConditionType, Condition.class,
+                    index);
+            try {
+                optional = CRD_CHECKING_CONDITION.equals(conditionInfo.name())
+                        || JandexUtil.isSubclassOf(index, conditionInfo, CRD_CHECKING_CONDITION);
+            } catch (BuildException e) {
+                optional = false;
+            }
+        }
+    }
+
+    /**
+     * Determines whether the associated dependent is defined as optional either because it uses an activation condition that
+     * derives from {@link io.javaoperatorsdk.operator.processing.dependent.workflow.CRDPresentActivationCondition} or because
+     * it was explicitly annotated as such using {@link io.quarkiverse.operatorsdk.annotations.CSVMetadata.Optional}
+     *
+     * @return whether the associated dependent is defined as optional
+     * @since 7.3.0
+     */
+    public boolean isOptional() {
+        // if we have a matching condition, we're done, otherwise check if the dependent is explicitly marked optional
+        // note that this is done here to minimize potentially useless processing in doAugment if this information is not needed
+        if (!optional) {
+            optional = Optional.ofNullable(classInfo().annotation(OPTIONAL_ANNOTATION))
+                    .map(ai -> Optional.ofNullable(ai.value()).map(AnnotationValue::asBoolean).orElse(true))
+                    .orElse(false);
+        }
+
+        return optional;
     }
 
     public AnnotationInstance getDependentAnnotationFromController() {


### PR DESCRIPTION
This can be done implicitly using an activation condition that derives
from CRDPresentActivationCondition or explicitly using
the CSVMetadata.Optional annotation.

Fixes #1154
