### PR TITLE
feat: fail at build time if a subclass of AbstractExternalDependentResource doesn't implement ResourceIDProvider

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/FailOnMissingResourceIDExternalResourceTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/FailOnMissingResourceIDExternalResourceTest.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.operatorsdk.test;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.operatorsdk.test.sources.ExternalDependentResourceMissingResourceID;
+import io.quarkiverse.operatorsdk.test.sources.TestCR;
+import io.quarkiverse.operatorsdk.test.sources.TestReconciler;
+import io.quarkus.test.QuarkusProdModeTest;
+
+public class FailOnMissingResourceIDExternalResourceTest {
+
+    @RegisterExtension
+    static final QuarkusProdModeTest config = new QuarkusProdModeTest()
+            .setExpectedException(IllegalStateException.class)
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(TestReconciler.class, TestCR.class,
+                            ExternalDependentResourceMissingResourceID.class));
+
+    @Test
+    public void shouldFailOnMissingResourceID() {
+        // should fail with deployment exception
+        Assertions.fail();
+    }
+
+}

--- a/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/ExternalDependentResourceMissingResourceID.java
+++ b/core/deployment/src/test/java/io/quarkiverse/operatorsdk/test/sources/ExternalDependentResourceMissingResourceID.java
@@ -1,0 +1,12 @@
+package io.quarkiverse.operatorsdk.test.sources;
+
+import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
+import io.javaoperatorsdk.operator.processing.dependent.AbstractExternalDependentResource;
+import io.javaoperatorsdk.operator.processing.event.source.EventSource;
+
+public class ExternalDependentResourceMissingResourceID extends AbstractExternalDependentResource {
+    @Override
+    protected EventSource createEventSource(EventSourceContext eventSourceContext) {
+        return null;
+    }
+}


### PR DESCRIPTION
Fixes #1212 

From what I understand from usages and https://javaoperatorsdk.io/docs/migration/v5-2-migration/ this should be enough.