### PR TITLE
fix: add required permissions to the release-snapshot-on-push-selected-branches workflow

### DIFF
--- a/.github/workflows/release-snapshot-on-push-selected-branches.yml
+++ b/.github/workflows/release-snapshot-on-push-selected-branches.yml
@@ -8,6 +8,11 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  attestations: write
+  id-token: write
+  contents: read
+
 jobs:
   release-snapshot:
     uses: ./.github/workflows/release-snapshot.yml


### PR DESCRIPTION
-