### PR TITLE
docs: include attributes.adoc in deploy-with-olm page

### DIFF
--- a/docs/modules/ROOT/pages/deploy-with-olm.adoc
+++ b/docs/modules/ROOT/pages/deploy-with-olm.adoc
@@ -1,3 +1,5 @@
+include::./includes/attributes.adoc[]
+
 = Deploying your operator with OLM
 
 The https://olm.operatorframework.io/[Operator Lifecycle Manager (OLM)] provides a declarative way to install, manage and upgrade operators on Kubernetes clusters.
@@ -21,7 +23,7 @@ Then, you need to add the `quarkus-operator-sdk-bundle-generator` extension to y
 <dependency>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-bundle-generator</artifactId>
-    <version>{page-component-version}</version>
+    <version>{project-version}</version>
 </dependency>
 ----
 

--- a/docs/modules/ROOT/pages/deploy-with-olm.adoc
+++ b/docs/modules/ROOT/pages/deploy-with-olm.adoc
@@ -21,7 +21,7 @@ Then, you need to add the `quarkus-operator-sdk-bundle-generator` extension to y
 <dependency>
     <groupId>io.quarkiverse.operatorsdk</groupId>
     <artifactId>quarkus-operator-sdk-bundle-generator</artifactId>
-    <version>{project-version}</version>
+    <version>{page-component-version}</version>
 </dependency>
 ----
 


### PR DESCRIPTION
## Summary
- The page uses {project-version} but never included the attributes file where it's defined. 
- Add the include directive, matching the pattern used by index.adoc
- Fixes 1 warning during the quarkiverse-docs Antora build

## Test plan
- [ ] Verify the Maven dependency snippet renders the correct version in the documentation