### PR TITLE
fix(tmp): replace removed annotation

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/devui/commands/ConsoleCommands.java
+++ b/core/deployment/src/main/java/io/quarkiverse/operatorsdk/deployment/devui/commands/ConsoleCommands.java
@@ -7,7 +7,7 @@ import org.aesh.command.invocation.CommandInvocation;
 
 import io.quarkiverse.operatorsdk.runtime.Version;
 
-@GroupCommandDefinition(name = "qosdk", description = "Quarkus Operator SDK Commands")
+@CommandDefinition(name = "qosdk", description = "Quarkus Operator SDK Commands")
 @SuppressWarnings("rawtypes")
 public class ConsoleCommands implements GroupCommand {
     private final Version version;


### PR DESCRIPTION
Note that this is, maybe, a temporary fix since children commands are
not currently properly detected with this fix.
It has, however, the advantage of being backwards-compatible for the time being.
