### PR TITLE
Bump java-operator-sdk.version from 5.5.1 to 5.6.0 and fix build

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusInformerConfiguration.java
+++ b/core/runtime/src/main/java/io/quarkiverse/operatorsdk/runtime/QuarkusInformerConfiguration.java
@@ -7,6 +7,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.informers.cache.ItemStore;
 import io.javaoperatorsdk.operator.api.config.informer.InformerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Constants;
+import io.javaoperatorsdk.operator.processing.GroupVersionKind;
 import io.javaoperatorsdk.operator.processing.event.source.filter.GenericFilter;
 import io.javaoperatorsdk.operator.processing.event.source.filter.OnAddFilter;
 import io.javaoperatorsdk.operator.processing.event.source.filter.OnDeleteFilter;
@@ -16,13 +17,15 @@ import io.quarkus.runtime.annotations.RecordableConstructor;
 public class QuarkusInformerConfiguration<R extends HasMetadata> extends InformerConfiguration<R> {
 
     @RecordableConstructor
-    public QuarkusInformerConfiguration(Class<R> resourceClass, String name, Set<String> namespaces,
+    public QuarkusInformerConfiguration(Class<R> resourceClass, GroupVersionKind resourceGroupVersionKind, String name,
+            Set<String> namespaces,
             boolean followControllerNamespaceChanges, String labelSelector, String shardSelector,
             OnAddFilter<? super R> onAddFilter,
             OnUpdateFilter<? super R> onUpdateFilter, OnDeleteFilter<? super R> onDeleteFilter,
             GenericFilter<? super R> genericFilter, ItemStore<R> itemStore, Long informerListLimit,
             QuarkusFieldSelector fieldSelector, boolean comparableResourceVersions) {
-        super(resourceClass, name, namespaces, followControllerNamespaceChanges, labelSelector, shardSelector, onAddFilter,
+        super(resourceClass, resourceGroupVersionKind, name, namespaces, followControllerNamespaceChanges, labelSelector,
+                shardSelector, onAddFilter,
                 onUpdateFilter,
                 onDeleteFilter, genericFilter, itemStore, informerListLimit, fieldSelector, comparableResourceVersions,
                 // hardcode this value for now as it will probably move away with a future FKC update
@@ -31,6 +34,7 @@ public class QuarkusInformerConfiguration<R extends HasMetadata> extends Informe
 
     public QuarkusInformerConfiguration(InformerConfiguration<R> config) {
         this(config.getResourceClass(),
+                config.getResourceGroupVersionKind(),
                 config.getName(),
                 sanitizeNamespaces(config.getNamespaces()),
                 config.getFollowControllerNamespaceChanges(),

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.release>17</maven.compiler.release>
     <quarkus.version>3.39.2</quarkus.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
-    <java-operator-sdk.version>5.5.1</java-operator-sdk.version>
+    <java-operator-sdk.version>5.6.0</java-operator-sdk.version>
     <io.quarkiverse.helm.version>1.4.3</io.quarkiverse.helm.version>
   </properties>
   <scm>


### PR DESCRIPTION
InformerConfiguration's constructor now takes an additional GroupVersionKind parameter; plumb it through QuarkusInformerConfiguration.

Supersedes https://github.com/quarkiverse/quarkus-operator-sdk/pull/1418

Didn't do interactive test of this change. Just ensuring it compiled.

Will let CI perform more validation

I'm very interested by using `5.6.0` for the `eventRecorder()`